### PR TITLE
Rename build_bazel_rules_android to rules_android

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use the new Bazel Android rules, add the following to your WORKSPACE file:
 
     load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
     http_archive(
-        name = "build_bazel_rules_android",
+        name = "rules_android",
         urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
         sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
         strip_prefix = "rules_android-0.1.1",
@@ -23,7 +23,7 @@ To use the new Bazel Android rules, add the following to your WORKSPACE file:
 
 Then, in your BUILD files, import and use the rules:
 
-    load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+    load("@rules_android//android:rules.bzl", "android_library")
     android_library(
         ...
     )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,3 +1,3 @@
-workspace(name = "build_bazel_rules_android")
+workspace(name = "rules_android")
 
 register_toolchains("//android/toolchains/emulator:all")


### PR DESCRIPTION
For simplicity and consisntency with other official rules like:
rules_java and rules_jvm_external.

See:

- https://github.com/bazelbuild/rules_java/releases/tag/0.1.0
- https://github.com/bazelbuild/rules_jvm_external/releases/tag/2.7

Also related to https://github.com/bazelbuild/bazel/pull/9220