### PR TITLE
Enable persistent worker mode for busybox actions

### DIFF
--- a/rules/busybox.bzl
+++ b/rules/busybox.bzl
@@ -281,7 +281,8 @@ def _package(
     transitive_input_files = []
 
     args = ctx.actions.args()
-    args.use_param_file("@%s")
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "AAPT2_PACKAGE")
     args.add("--")
     args.add("--aapt2", aapt.executable)
@@ -398,6 +399,8 @@ def _package(
         outputs = output_files,
         mnemonic = "PackageAndroidResources",
         progress_message = "Packaging Android Resources in %s" % ctx.label,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _parse(
@@ -418,7 +421,8 @@ def _parse(
       host_javabase: Target. The host javabase.
     """
     args = ctx.actions.args()
-    args.use_param_file("@%s")
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "PARSE")
     args.add("--")
     args.add(
@@ -439,6 +443,8 @@ def _parse(
         outputs = [out_symbols],
         mnemonic = "ParseAndroidResources",
         progress_message = "Parsing Android Resources in %s" % out_symbols.short_path,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _make_merge_assets_flags(resources_node):
@@ -484,7 +490,8 @@ def _merge_assets(
       host_javabase: Target. The host javabase.
     """
     args = ctx.actions.args()
-    args.use_param_file("@%s")
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "MERGE_ASSETS")
     args.add("--")
     args.add("--assetsOutput", out_assets_zip)
@@ -514,6 +521,7 @@ def _merge_assets(
         ctx = ctx,
         host_javabase = host_javabase,
         executable = busybox,
+        tools = [busybox],
         arguments = [args],
         inputs = depset(
             assets + [symbols],
@@ -523,6 +531,8 @@ def _merge_assets(
         mnemonic = "MergeAndroidAssets",
         progress_message =
             "Merging Android Assets in %s" % out_assets_zip.short_path,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _validate_and_link(
@@ -562,7 +572,8 @@ def _validate_and_link(
 
     # Retrieves the list of files at runtime when a directory is passed.
     args = ctx.actions.args()
-    args.use_param_file("@%s")
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "LINK_STATIC_LIBRARY")
     args.add("--")
     args.add("--aapt2", aapt.executable)
@@ -598,6 +609,8 @@ def _validate_and_link(
         mnemonic = "LinkAndroidResources",
         progress_message =
             "Linking Android Resources in " + out_file.short_path,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _compile(
@@ -627,7 +640,8 @@ def _compile(
 
     # Retrieves the list of files at runtime when a directory is passed.
     args = ctx.actions.args()
-    args.use_param_file("@%s")
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "COMPILE_LIBRARY_RESOURCES")
     args.add("--")
     args.add("--aapt2", aapt.executable)
@@ -651,6 +665,8 @@ def _compile(
         outputs = [out_file],
         mnemonic = "CompileAndroidResources",
         progress_message = "Compiling Android Resources in %s" % out_file.short_path,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _make_merge_compiled_flags(resources_node_info):
@@ -703,7 +719,8 @@ def _merge_compiled(
     transitive_input_files = []
 
     args = ctx.actions.args()
-    args.use_param_file("@%s")
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "MERGE_COMPILED")
     args.add("--")
     args.add("--classJarOutput", out_class_jar)
@@ -746,12 +763,15 @@ def _merge_compiled(
         ctx = ctx,
         host_javabase = host_javabase,
         executable = busybox,
+        tools = [busybox],
         arguments = [args],
         inputs = depset(input_files, transitive = transitive_input_files),
         outputs = output_files,
         mnemonic = "StarlarkMergeCompiledAndroidResources",
         progress_message =
             "Merging compiled Android Resources in " + out_class_jar.short_path,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _escape_mv(s):
@@ -812,6 +832,7 @@ def _merge_manifests(
     # Args for busybox
     args = ctx.actions.args()
     args.use_param_file("@%s", use_always = True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "MERGE_MANIFEST")
     args.add("--")
     if manifest:
@@ -838,11 +859,14 @@ def _merge_manifests(
         ctx = ctx,
         host_javabase = host_javabase,
         executable = busybox,
+        tools = [busybox],
         arguments = [args],
         inputs = depset(directs, transitive = transitives),
         outputs = outputs,
         mnemonic = "MergeManifests",
         progress_message = "Merging Android Manifests in %s" % out_file.short_path,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _process_databinding(
@@ -877,6 +901,8 @@ def _process_databinding(
     res_dirs = _get_unique_res_dirs(resource_files)
 
     args = ctx.actions.args()
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "PROCESS_DATABINDING")
     args.add("--")
     args.add("--output_resource_directory", databinding_resources_dirname)
@@ -893,6 +919,8 @@ def _process_databinding(
         outputs = [out_databinding_info] + out_databinding_processed_resources,
         mnemonic = "StarlarkProcessDatabinding",
         progress_message = "Processing data binding",
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _make_generate_binay_r_flags(resources_node):
@@ -931,6 +959,8 @@ def _generate_binary_r(
       host_javabase: A Target. The host javabase.
     """
     args = ctx.actions.args()
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "GENERATE_BINARY_R")
     args.add("--")
     args.add("--primaryRTxt", r_txt)
@@ -950,17 +980,19 @@ def _generate_binary_r(
     # TODO(b/154003916): support transitive "--library transitive_r_txt_path,transitive_manifest_path" flags
     args.add("--classJarOutput", out_class_jar)
     args.add("--targetLabel", str(ctx.label))
-    args.use_param_file("@%s")
 
     _java.run(
         ctx = ctx,
         host_javabase = host_javabase,
         executable = busybox,
+        tools = [busybox],
         arguments = [args],
         inputs = depset([r_txt, manifest], transitive = transitive_r_txts + transitive_manifests),
         outputs = [out_class_jar],
         mnemonic = "StarlarkRClassGenerator",
         progress_message = "Generating R classes",
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 def _make_aar(
@@ -995,6 +1027,8 @@ def _make_aar(
         when a resource conflict occurs.
     """
     args = ctx.actions.args()
+    args.use_param_file("@%s", use_always=True)
+    args.set_param_file_format("multiline")
     args.add("--tool", "GENERATE_AAR")
     args.add("--")
     args.add(
@@ -1018,6 +1052,7 @@ def _make_aar(
         ctx = ctx,
         host_javabase = host_javabase,
         executable = busybox,
+        tools = [busybox],
         arguments = [args],
         inputs = (
             resource_files +
@@ -1028,6 +1063,8 @@ def _make_aar(
         outputs = [out_aar],
         mnemonic = "StarlarkAARGenerator",
         progress_message = "Generating AAR package for %s" % ctx.label,
+        supports_workers = True,
+        supports_multiplex_workers = True,
     )
 
 busybox = struct(

--- a/rules/busybox.bzl
+++ b/rules/busybox.bzl
@@ -118,6 +118,10 @@ def _make_resources_flag(
         ],
     )
 
+def _disable_warnings(args):
+    # Disable warnings - this are output to stdin/stderr which breaks worker mode
+    args.add("--logWarnings=false")
+
 def _path(f):
     return f.path
 
@@ -389,11 +393,13 @@ def _package(
     if java_package:
         args.add("--packageForR", java_package)
 
+    _disable_warnings(args)
+
     _java.run(
         ctx = ctx,
         host_javabase = host_javabase,
         executable = busybox,
-        tools = [aapt],
+        tools = [aapt, busybox],
         arguments = [args],
         inputs = depset(input_files, transitive = transitive_input_files),
         outputs = output_files,
@@ -433,6 +439,8 @@ def _parse(
         ),
     )
     args.add("--output", out_symbols)
+
+    _disable_warnings(args)
 
     _java.run(
         ctx = ctx,
@@ -517,6 +525,8 @@ def _merge_assets(
         join_with = "&",
     )
 
+    _disable_warnings(args)
+
     _java.run(
         ctx = ctx,
         host_javabase = host_javabase,
@@ -598,6 +608,8 @@ def _validate_and_link(
     args.add("--staticLibraryOut", out_file)
     output_files.append(out_file)
 
+    _disable_warnings(args)
+
     _java.run(
         ctx = ctx,
         host_javabase = host_javabase,
@@ -654,6 +666,8 @@ def _compile(
         ),
     )
     args.add("--output", out_file)
+
+    _disable_warnings(args)
 
     _java.run(
         ctx = ctx,
@@ -759,6 +773,8 @@ def _merge_compiled(
         )
         transitive_input_files.append(transitive_compiled_resources)
 
+    _disable_warnings(args)
+
     _java.run(
         ctx = ctx,
         host_javabase = host_javabase,
@@ -855,6 +871,8 @@ def _merge_manifests(
         args.add("--log", out_log_file)
         outputs.append(out_log_file)
 
+    _disable_warnings(args)
+
     _java.run(
         ctx = ctx,
         host_javabase = host_javabase,
@@ -909,6 +927,8 @@ def _process_databinding(
     args.add_all(res_dirs, before_each = "--resource_root")
     args.add("--dataBindingInfoOut", out_databinding_info)
     args.add("--appId", java_package)
+
+    _disable_warnings(args)
 
     _java.run(
         ctx = ctx,
@@ -981,6 +1001,8 @@ def _generate_binary_r(
     args.add("--classJarOutput", out_class_jar)
     args.add("--targetLabel", str(ctx.label))
 
+    _disable_warnings(args)
+
     _java.run(
         ctx = ctx,
         host_javabase = host_javabase,
@@ -1047,6 +1069,8 @@ def _make_aar(
     args.add_all(proguard_specs, before_each = "--proguardSpec")
     if should_throw_on_conflict:
         args.add("--throwOnResourceConflict")
+
+    _disable_warnings(args)
 
     _java.run(
         ctx = ctx,

--- a/rules/java.bzl
+++ b/rules/java.bzl
@@ -431,7 +431,17 @@ def _run(
 
     args["arguments"] = jvm_flags + [jar_args] + args.get("arguments", default = [])
 
-    ctx.actions.run(**args)
+    mnemonic = args.get("mnemonic")
+    supports_workers = args.pop("supports_workers", False)
+    supports_multiplex_workers = args.pop("supports_multiplex_workers", False)
+    execution_requirements = args.pop("execution_requirements", dict())
+    if supports_workers:
+        execution_requirements["worker-key-mnemonic"] = mnemonic
+        execution_requirements["supports-workers"] = "1"
+        if supports_multiplex_workers:
+            execution_requirements["supports-multiplex-workers"] = "1"
+
+    ctx.actions.run(execution_requirements = execution_requirements, **args)
 
 java = struct(
     compile = _compile,


### PR DESCRIPTION
- Adds `supports-worker` and `supports_multiplex_workers` to execution requirements
-  Forces use of param file
- Disable warnings to avoid corrupting stdout/stderr 