### PR TITLE
Define common Android platforms

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,36 @@
+"""Common definitions useful for Android builds."""
+
+package(default_visibility = ["//visibility:public"])
+
+platform(
+    name = "x86",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86_32",
+    ],
+)
+
+platform(
+    name = "x86_64",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "armeabi-v7a",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:armv7",
+    ],
+)
+
+platform(
+    name = "arm64-v8a",
+    constraint_values =
+        [
+            "@platforms//cpu:arm64",
+            "@platforms//os:android",
+        ],
+)

--- a/android/utils.bzl
+++ b/android/utils.bzl
@@ -98,7 +98,7 @@ def _get_runfiles(ctx, attrs):
 def _sanitize_string(s, replacement = ""):
     """Sanitizes a string by replacing all non-word characters.
 
-    This matches the \w regex character class [A_Za-z0-9_].
+    This matches the \\w regex character class [A_Za-z0-9_].
 
     Args:
       s: String to sanitize.


### PR DESCRIPTION
This is work towards enabling platforms and toolchains for Android builds (bazelbuild/bazel#16285).

(Also contains https://github.com/bazelbuild/rules_android/pull/56 until that is merged and I rebase).