### PR TITLE
[SNAP FORK][UPSTREAMED] Fix idl tool

### DIFF
--- a/rules/intellij.bzl
+++ b/rules/intellij.bzl
@@ -32,7 +32,10 @@ def _extract_idl_jars(
     args.add("--manifest_proto", manifest_proto)
     args.add("--output_class_jar", out_jar)
     args.add("--output_source_jar", out_srcjar)
-    args.add("--temp_dir", out_jar.dirname)
+
+    # tmp directory is removed by the idl tool before each invocation so create a unique dir.
+    # See src/main/java/com/google/devtools/build/lib/rules/android/AndroidIdlHelper.java
+    args.add("--temp_dir", "%s/%s_idl_tmp" % (out_jar.dirname, ctx.label.name))
     args.add_all(idl_java_srcs)
 
     _java.run(

--- a/toolchains/android/toolchain.bzl
+++ b/toolchains/android/toolchain.bzl
@@ -130,7 +130,7 @@ _ATTRS = dict(
     idlclass = attr.label(
         allow_files = True,
         cfg = "exec",
-        default = "@bazel_tools//tools/android:IdlClass",  # _deploy.jar?
+        default = "@bazel_tools//src/tools/android/java/com/google/devtools/build/android/idlclass:IdlClass_deploy.jar",
         executable = True,
     ),
     import_deps_checker = attr.label(


### PR DESCRIPTION
- Using deploy jar, since tool is exectuted as java -jar. Otherwise artifact is the sh runner file.
- Create a unique directory for the tmp directory for idl. This directory is removed on each execution so passing the runfileles dir will delete all inputs. seel https://livegrep.sc-corp.net/view/Snapchat/bazel/src/main/java/com/google/devtools/build/lib/rules/android/AndroidIdlHelper.java#L348