### PR TITLE
Set visibility of merge_feature_manifests.par to public

### DIFF
--- a/rules/android_application/BUILD
+++ b/rules/android_application/BUILD
@@ -41,5 +41,6 @@ filegroup(
     name = "merge_feature_manifests.par",
     srcs = [":merge_feature_manifests"],
     output_group = "python_zip_file",
+    visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
`merge_feature_manifests` is missing the necessary visibility modifiers needed to use it in a build.

```
(16:01:53) ERROR: ... target '@rules_android//rules/android_application:merge_feature_manifests.par' is not visible from target ... Check the visibility declaration of the former target if you think the dependency is legitimate
```