### PR TITLE
Proxy native.android_local_test in android/rules.bzl

### DIFF
--- a/android/rules.bzl
+++ b/android/rules.bzl
@@ -60,3 +60,4 @@ android_ndk_repository = _android_ndk_repository
 android_sdk = _android_sdk
 android_sdk_repository = _android_sdk_repository
 android_tools_defaults_jar = _android_tools_defaults_jar
+android_local_test = native.android_local_test


### PR DESCRIPTION
Mirroring https://github.com/bazelbuild/rules_android/blob/master/android/rules.bzl#L102 to not break compatibility when swapping the pre-alpha rules in.