### PR TITLE
Add com.android.tools.build:gradle to MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -36,6 +36,7 @@ maven.install(
     name = "rules_android_maven",
     artifacts = [
         "com.android.tools.build:bundletool:1.6.1",
+        "com.android.tools.build:gradle:8.0.1",
     ],
     repositories = [
         "https://maven.google.com",


### PR DESCRIPTION
The `com.android.tools.build:gradle` maven dependency was added to the workspace maven install list, but not the Bazelmod maven install list.