### PR TITLE
Support propagate_transitive_resources_class_jars

### DIFF
--- a/rules/android_library/impl.bzl
+++ b/rules/android_library/impl.bzl
@@ -176,6 +176,7 @@ def _process_resources(ctx, java_package, manifest_ctx, **unused_ctxs):
         # misbehavior on the Java side.
         fix_resource_transitivity = bool(ctx.attr.srcs),
         fix_export_exporting = acls.in_fix_export_exporting_rollout(str(ctx.label)),
+        propagate_transitive_resources_class_jars = _flags.get(ctx).propagate_transitive_resources_class_jars,
 
         # Tool and Processing related inputs
         aapt = get_android_toolchain(ctx).aapt2.files_to_run,

--- a/rules/flags/flag_defs.bzl
+++ b/rules/flags/flag_defs.bzl
@@ -97,3 +97,9 @@ def define_flags():
         default = True,
         description = "Use Studio Deployer to install apks",
     )
+
+    flags.DEFINE_bool(
+        name = "propagate_transitive_resources_class_jars",
+        default = True,
+        description = "Collect and propagate transitive resources class jars from dependencies",
+    )

--- a/rules/resources.bzl
+++ b/rules/resources.bzl
@@ -1180,6 +1180,7 @@ def _process_starlark(
         neverlink = False,
         enable_data_binding = False,
         propagate_resources = True,
+        propagate_transitive_resources_class_jars = True,
         fix_resource_transitivity = False,
         aapt = None,
         android_jar = None,
@@ -1230,6 +1231,9 @@ def _process_starlark(
       propagate_resources: boolean. If false, the target will no longer propagate
         providers required for Android Resource processing/packaging. But will
         continue to propagate others (AndroidLibraryResourceClassJarProvider).
+      propagate_transitive_resources_class_jars: boolean. If false, the target will no longer propagate
+        the transitive Android Resource class jars as part of the AndroidLibraryResourceClassJarProvider
+        provider and will only propagate the direct Android Resource class jar.
       fix_resource_transitivity: Whether to ensure that transitive resources are
         correctly marked as transitive.
       aapt: FilesToRunProvider. The aapt executable or FilesToRunProvider.
@@ -1789,14 +1793,13 @@ def _process_starlark(
                         deps,
                         exports,
                     )
-                ],
+                ] if propagate_transitive_resources_class_jars else [],
                 order = "preorder",
             ),
         ),
     )
 
     return resources_ctx
-
 
 def _process(
         ctx,
@@ -1828,6 +1831,7 @@ def _process(
         fix_resource_transitivity = False,
         fix_export_exporting = False,
         propagate_resources = True,
+        propagate_transitive_resources_class_jars = True,
         zip_tool = None):
     out_ctx = _process_starlark(
         ctx,
@@ -1851,6 +1855,7 @@ def _process(
         fix_resource_transitivity = fix_resource_transitivity,
         neverlink = neverlink,
         propagate_resources = propagate_resources,
+        propagate_transitive_resources_class_jars = propagate_transitive_resources_class_jars,
         android_jar = android_jar,
         aapt = aapt,
         android_kit = android_kit,
@@ -1861,7 +1866,6 @@ def _process(
         host_javabase = host_javabase,
         zip_tool = zip_tool,
     )
-
 
     if _VALIDATION_OUTPUTS not in out_ctx:
         out_ctx[_VALIDATION_OUTPUTS] = []


### PR DESCRIPTION
Supports enabling/disabling the collection and propagation of transitive R files as part of the `AndroidLibraryResourceClassJarProvider` making it possible to only compile against the direct Android resource class jars. 
