### PR TITLE
Pass string values to execution_requirements

### DIFF
--- a/rules/dex.bzl
+++ b/rules/dex.bzl
@@ -131,9 +131,9 @@ def _dex(
 
     execution_requirements = {}
     if ctx.fragments.android.persistent_android_dex_desugar:
-        execution_requirements["supports-workers"] = 1
+        execution_requirements["supports-workers"] = "1"
         if ctx.fragments.android.persistent_multiplex_android_dex_desugar:
-            execution_requirements["supports-multiplex-workers"] = 1
+            execution_requirements["supports-multiplex-workers"] = "1"
 
     ctx.actions.run(
         executable = dex_exec,


### PR DESCRIPTION
Bazel requires that execution requirements are a dictionary of strings and errors out when ints are passed.

```
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/build_bazel_rules_android/rules/dex_desugar_aspect.bzl", line 100, column 25, in _aspect_impl
                _dex.dex(
        File "/private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/build_bazel_rules_android/rules/dex.bzl", line 138, column 20, in _dex
                ctx.actions.run(
Error in run: got dict<string, int> for 'execution_requirements', want dict<string, string>
```