### PR TITLE
Enable conditional merging of manifest permissions

### DIFF
--- a/rules/aar_import/rule.bzl
+++ b/rules/aar_import/rule.bzl
@@ -41,7 +41,10 @@ def _impl_proxy(ctx):
 
 aar_import = rule(
     attrs = _ATTRS,
-    fragments = ["android"],
+    fragments = [
+        "android",
+        "bazel_android",
+    ],
     implementation = _impl_proxy,
     doc = RULE_DOC,
     provides = [

--- a/rules/android_application/android_application_rule.bzl
+++ b/rules/android_application/android_application_rule.bzl
@@ -328,6 +328,7 @@ android_application = rule(
     cfg = android_common.android_platforms_transition,
     fragments = [
         "android",
+        "bazel_android",
         "java",
     ],
     executable = True,

--- a/rules/android_application/android_feature_module_rule.bzl
+++ b/rules/android_application/android_feature_module_rule.bzl
@@ -74,6 +74,7 @@ android_feature_module = rule(
     attrs = ANDROID_FEATURE_MODULE_ATTRS,
     fragments = [
         "android",
+        "bazel_android",
         "java",
     ],
     implementation = _impl,

--- a/rules/android_binary_internal/rule.bzl
+++ b/rules/android_binary_internal/rule.bzl
@@ -52,6 +52,7 @@ def make_rule(
         _skylark_testable = True,
         fragments = [
             "android",
+            "bazel_android",
             "java",
             "cpp",
         ],

--- a/rules/android_library/rule.bzl
+++ b/rules/android_library/rule.bzl
@@ -158,7 +158,6 @@ def make_rule(
             "android",
             "bazel_android",
             "java",
-            "cpp",
         ],
         implementation = implementation,
         doc = _RULE_DOC,

--- a/rules/android_library/rule.bzl
+++ b/rules/android_library/rule.bzl
@@ -156,7 +156,9 @@ def make_rule(
         attrs = attrs,
         fragments = [
             "android",
+            "bazel_android",
             "java",
+            "cpp",
         ],
         implementation = implementation,
         doc = _RULE_DOC,

--- a/rules/busybox.bzl
+++ b/rules/busybox.bzl
@@ -838,6 +838,10 @@ def _merge_manifests(
         [mergee_manifests],
         map_each = _mergee_manifests_flag,
     )
+
+    if ctx.fragments.bazel_android.merge_android_manifest_permissions:
+      args.add("--mergeManifestPermissions")
+               
     if manifest_values:
         args.add(
             "--manifestValues",


### PR DESCRIPTION
Enables merging manifest permissions using `--merge_android_manifest_permissions` flag.

Depends on https://github.com/bazelbuild/bazel/pull/18665