### PR TITLE
Add standard platforms for old rules_android

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,34 @@
+# Common default platform definitions for use by Android projects.
+
+platform(
+    name = "x86",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86_32",
+    ],
+)
+
+platform(
+    name = "x86_64",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:x86_64",
+    ],
+)
+
+platform(
+    name = "armeabi-v7a",
+    constraint_values = [
+        "@platforms//os:android",
+        "@platforms//cpu:armv7",
+    ],
+)
+
+platform(
+    name = "arm64-v8a",
+    constraint_values =
+        [
+            "@platforms//cpu:arm64",
+            "@platforms//os:android",
+        ],
+)


### PR DESCRIPTION
Adding the standard platforms to older rules_android will make it possible to do gradual transition: first flipping --incompatible_enable_android_toolchain_resolution and independently of this switching from old to new version of rules_android.

This will require a compatibility release of old rules_android.