### PR TITLE
Add an ability to exclude files from final binary produces by android_application

### DIFF
--- a/rules/android_application/android_application_rule.bzl
+++ b/rules/android_application/android_application_rule.bzl
@@ -273,14 +273,22 @@ def _impl(ctx):
         metadata["com.google.play.apps.integrity/AppIntegrityConfig.pb"] = ctx.file.app_integrity_config
 
     # Create .aab
+    base_aab = ctx.actions.declare_file("base_aab")
     _bundletool.build(
         ctx,
-        out = ctx.outputs.unsigned_aab,
+        out = base_aab,
         modules = modules,
         config = ctx.file.bundle_config_file,
         metadata = metadata,
         bundletool = get_android_toolchain(ctx).bundletool.files_to_run,
         host_javabase = _common.get_host_javabase(ctx),
+    )
+
+    _common.filter_zip_exclude(
+        ctx = ctx,
+        input = base_aab,
+        output = ctx.outputs.unsigned_aab,
+        filters = ctx.attr.excludes,
     )
 
     # Create `blaze run` script
@@ -380,6 +388,9 @@ def android_application_macro(_android_binary, **attrs):
         module_targets = get_feature_module_paths(feature_module)
         attrs["deps"].append(str(module_targets.title_lib))
 
+    # only supported in android_application rule
+    excludes = attrs.pop("excludes", [])
+
     _android_binary(
         name = base_split_name,
         **attrs
@@ -397,4 +408,5 @@ def android_application_macro(_android_binary, **attrs):
         feature_modules = feature_modules,
         application_id = attrs["manifest_values"]["applicationId"],
         visibility = attrs.get("visibility", None),
+        excludes = excludes,
     )

--- a/rules/android_application/attrs.bzl
+++ b/rules/android_application/attrs.bzl
@@ -42,6 +42,10 @@ ANDROID_APPLICATION_ATTRS = _attrs.add(
         ),
         custom_package = attr.string(),
         feature_modules = attr.label_list(allow_files = False),
+        excludes = attr.string_list(
+            doc = "List of regex file patterns to exclude from the final binary. If you use excludes, make sure that" +
+                  " you do not utilise any code path requiring the excluded dependency by sufficient test coverage."
+        ),
         _bundle_deploy = attr.label(
             allow_single_file = True,
             default = ":bundle_deploy.sh_template",


### PR DESCRIPTION

Gradle supports excluding artifacts from modules using the exclude keyword. This functionality is used across the Android ecosystem to exclude artifacts from the final APK mainly to reduce app size.

This PR adds new `excludes` attribute to `android_application` which supports a list of regex file patterns to exclude from the final binary (`aab`).