### PR TITLE
Make Android toolchain type a Label

### DIFF
--- a/rules/utils.bzl
+++ b/rules/utils.bzl
@@ -16,7 +16,7 @@
 
 load(":providers.bzl", "FailureInfo")
 
-ANDROID_TOOLCHAIN_TYPE = "@build_bazel_rules_android//toolchains/android:toolchain_type"
+ANDROID_TOOLCHAIN_TYPE = Label("//toolchains/android:toolchain_type")
 
 _CUU = "\033[A"
 _EL = "\033[K"

--- a/rules/utils.bzl
+++ b/rules/utils.bzl
@@ -16,7 +16,7 @@
 
 load(":providers.bzl", "FailureInfo")
 
-ANDROID_TOOLCHAIN_TYPE = "//toolchains/android:toolchain_type"
+ANDROID_TOOLCHAIN_TYPE = "@build_bazel_rules_android//toolchains/android:toolchain_type"
 
 _CUU = "\033[A"
 _EL = "\033[K"


### PR DESCRIPTION
Starting with commit https://github.com/bazelbuild/rules_android/commit/0101f29a8179c8ee1421dbd545a2db5c4ef77e0e#diff-154bb7fd9a9984b3a44bb15790e6f63b0e021249908516d3d1e21948e2a3fc31R19 builds are failing because the toolchain is being resolved to the correct repository namespace. Example:

```
(08:48:14) ERROR: /private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/maven/BUILD:7201:11: in aar_import rule @maven//:androidx_print_print:
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/build_bazel_rules_android/rules/aar_import/rule.bzl", line 43, column 25, in _impl_proxy
                providers, _ = _impl(ctx)
        File "/private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/build_bazel_rules_android/rules/aar_import/impl.bzl", line 469, column 24, in impl
                extract_single_file(
        File "/private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/build_bazel_rules_android/rules/aar_import/impl.bzl", line 66, column 26, in extract_single_file
                ctx.actions.run_shell(
Error in run_shell: Action declared for non-existent toolchain '@maven//toolchains/android:toolchain_type'.
```

Seems related to https://github.com/bazelbuild/bazel/issues/19286