### PR TITLE
Increase R8 allowed max memory usage

### DIFF
--- a/rules/android_binary_internal/r8.bzl
+++ b/rules/android_binary_internal/r8.bzl
@@ -92,7 +92,7 @@ def process_r8(ctx, jvm_ctx, packaged_resources_ctx, build_info_ctx, **_unused_c
         inputs = [android_jar, deploy_jar] + proguard_specs,
         outputs = [dexes_zip],
         mnemonic = "AndroidR8",
-        jvm_flags = ["-Xms4G", "-Xmx8G"],
+        jvm_flags = ["-Xmx8G"],
         progress_message = "R8 Optimizing, Desugaring, and Dexing %{label}",
     )
 

--- a/rules/android_binary_internal/r8.bzl
+++ b/rules/android_binary_internal/r8.bzl
@@ -92,6 +92,7 @@ def process_r8(ctx, jvm_ctx, packaged_resources_ctx, build_info_ctx, **_unused_c
         inputs = [android_jar, deploy_jar] + proguard_specs,
         outputs = [dexes_zip],
         mnemonic = "AndroidR8",
+        jvm_flags = ["-Xms4G", "-Xmx8G"],
         progress_message = "R8 Optimizing, Desugaring, and Dexing %{label}",
     )
 


### PR DESCRIPTION
We've seen this action OOM a few times in our codebase. The default `4g` max set by `java.bzl` probably isn't going to be enough for R8 to successfully dex, desugar, and optimize a large application.

Increasing the max allowed memory should be a safe change since R8 is one of the final actions in an apps build graph.