### PR TITLE
Improve bzlmod support for downstream users

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,3 +81,8 @@ bazel_binaries = use_extension(
 )
 bazel_binaries.download(version = "last_green")
 use_repo(bazel_binaries, "bazel_binaries")
+
+android_sdk_extension = use_extension("//rules/android_sdk_repository:rule.bzl", "android_sdk_extension")
+use_repo(android_sdk_extension, "androidsdk")
+
+register_toolchains("@androidsdk//:all")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -5,11 +5,6 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load(":android_sdk_supplemental_repository.bzl", "android_sdk_supplemental_repository")
 
 maybe(
-    android_sdk_repository,
-    name = "androidsdk",
-)
-
-maybe(
     android_ndk_repository,
     name = "androidndk",
 )

--- a/mobile_install/tools.bzl
+++ b/mobile_install/tools.bzl
@@ -91,7 +91,7 @@ TOOL_ATTRS = dict(
         executable = True,
     ),
     _d8 = attr.label(
-        default = Label("@bazel_tools//src/tools/android/java/com/google/devtools/build/android/r8:r8"),
+        default = Label("//tools/android:r8"),
         allow_files = True,
         cfg = "exec",
         executable = True,

--- a/rules/android_sdk_repository/helper.bzl
+++ b/rules/android_sdk_repository/helper.bzl
@@ -80,6 +80,42 @@ def _create_config_setting_rule():
         flag_values = {":allow_proguard": "false"},
     )
 
+def create_dummy_sdk_toolchain():
+    native.toolchain(
+        name = "sdk-dummy-toolchain",
+        toolchain = ":sdk-dummy",
+        toolchain_type = "@bazel_tools//tools/android:sdk_toolchain_type",
+    )
+
+    native.filegroup(name = "jar-filegroup", srcs = ["dummy.jar"])
+
+    native.genrule(
+        name = "genrule",
+        srcs = [],
+        outs = ["empty.sh"],
+        cmd = "echo '' >> \"$@\"",
+        executable = 1,
+    )
+
+    native.sh_binary(name = "empty-binary", srcs = [":genrule"])
+
+    native.android_sdk(
+        name = "sdk-dummy",
+        aapt = ":empty-binary",
+        adb = ":empty-binary",
+        aidl = ":empty-binary",
+        android_jar = ":jar-filegroup",
+        apksigner = ":empty-binary",
+        dx = ":empty-binary",
+        framework_aidl = "dummy.jar",
+        main_dex_classes = "dummy.jar",
+        main_dex_list_creator = ":empty-binary",
+        proguard = ":empty-binary",
+        shrinked_android_jar = "dummy.jar",
+        tags = ["__ANDROID_RULES_MIGRATION__"],
+        zipalign = ":empty-binary",
+    )
+
 def create_android_sdk_rules(
         name,
         build_tools_version,
@@ -234,6 +270,8 @@ def create_android_sdk_rules(
                 ":api_%d_enabled" % api_level,
             ],
         )
+
+    create_dummy_sdk_toolchain()
 
     native.alias(
         name = "org_apache_http_legacy",


### PR DESCRIPTION
This adds a way to setup the androidsdk repo in a bzlmod compatible way.