### PR TITLE
[WIP] Add a dummy Android SDK that does nothing.

### DIFF
--- a/rules/android_sdk_repository/helper.bzl
+++ b/rules/android_sdk_repository/helper.bzl
@@ -235,6 +235,8 @@ def create_android_sdk_rules(
             ],
         )
 
+    create_dummy_sdk_toolchain()
+
     native.alias(
         name = "org_apache_http_legacy",
         actual = ":org_apache_http_legacy-%d" % default_api_level,
@@ -505,3 +507,41 @@ def create_system_images_filegroups(system_image_dirs):
                 name = "%s_qemu2_extra" % name,
                 srcs = [],
             )
+
+# This is a dummy sdk toolchain that matches any platform. It will
+# fail if actually resolved to and used.
+def create_dummy_sdk_toolchain():
+    native.toolchain(
+        name = "sdk-dummy-toolchain",
+        toolchain = ":sdk-dummy",
+        toolchain_type = "@bazel_tools//tools/android:sdk_toolchain_type",
+    )
+
+    native.filegroup(name = "jar-filegroup", srcs = ["dummy.jar"])
+
+    native.genrule(
+        name = "genrule",
+        srcs = [],
+        outs = ["empty.sh"],
+        cmd = "echo '' >> \"$@\"",
+        executable = 1,
+    )
+
+    native.sh_binary(name = "empty-binary", srcs = [":genrule"])
+
+    native.android_sdk(
+        name = "sdk-dummy",
+        aapt = ":empty-binary",
+        adb = ":empty-binary",
+        aidl = ":empty-binary",
+        android_jar = ":jar-filegroup",
+        apksigner = ":empty-binary",
+        dx = ":empty-binary",
+        framework_aidl = "dummy.jar",
+        main_dex_classes = "dummy.jar",
+        main_dex_list_creator = ":empty-binary",
+        proguard = ":empty-binary",
+        shrinked_android_jar = "dummy.jar",
+        tags = ["__ANDROID_RULES_MIGRATION__"],
+        zipalign = ":empty-binary",
+    )

--- a/test/rules/android_sdk_repository/test_lib.sh
+++ b/test/rules/android_sdk_repository/test_lib.sh
@@ -33,6 +33,21 @@ source "$(rlocation rules_android/test/rules/android_sdk_repository/android_help
 
 # Actual tests for Android Sdk Repository
 
+# Test that the dummy SDK exists.
+function test_dummy_sdk() {
+  # Create android SDK
+  local sdk_path="$(create_android_sdk_basic)"
+
+  cat >> WORKSPACE <<EOF
+android_sdk_repository(
+    name = "androidsdk",
+    path = "${sdk_path}",
+)
+EOF
+
+  "${BIT_BAZEL_BINARY}" query @androidsdk//:sdk-dummy >& $TEST_log || fail "Dummy SDK missing"
+}
+
 # Check that the empty BUILD file was created.
 function test_android_sdk_repository_no_path_or_android_home() {
   cat >> WORKSPACE <<EOF


### PR DESCRIPTION
This allows any attempt to find an SDK to succeed, although the SDK is not useful and will then generate further errors.

Attempt to fix https://github.com/bazelbuild/bazel/issues/19600.