### PR TITLE
Revert "Add Android Platforms build flags."

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,8 +9,6 @@ x_defaults:
     - "//android/..."
     - "//rules/..."
     - "-//src/java/com/example/sampleapp/..."
-    - "-//src/tools/..."
-    - "-//src/common/golang/..."
     - "//toolchains/..."
     - "//tools/..."
     - "-//tools/android/..." # TODO(#122): Un-exclude this once #122 is fixed.
@@ -19,10 +17,6 @@ x_defaults:
     - "//test/..."
     - "-//src/tools/enforce_min_sdk_floor/..."
     - "-//src/java/com/example/sampleapp/..."
-    build_flags:
-    - "--incompatible_enable_android_toolchain_resolution"
-    - "--android_platforms=//:arm64-v8a"
-    - "--platforms=//:arm64-v8a"
     test_flags:
      # Sandboxed SDK tools depend on libraries that require Java runtime 17 or higher.
     - "--java_runtime_version=17"


### PR DESCRIPTION
Reverts bazelbuild/rules_android#162

This needed to be handled separately.