### PR TITLE
attempt to fix bzlmod

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -23,26 +23,44 @@ x_defaults:
 
 tasks:
   ubuntu2004:
+    build_flags:
+    - "--noenable_bzlmod"
+    test_flags:
+    - "--noenable_bzlmod"
     <<: *common
   macos:
+    build_flags:
+    - "--noenable_bzlmod"
+    test_flags:
+    - "--noenable_bzlmod"
     <<: *common
   macos_arm64:
+    build_flags:
+    - "--noenable_bzlmod"
+    test_flags:
+    - "--noenable_bzlmod"
     <<: *common
   ubuntu2004_bzlmod:
     name: Bzlmod ubuntu2004
     platform: ubuntu2004
     build_flags:
     - "--enable_bzlmod"
+    test_flags:
+    - "--enable_bzlmod"
     <<: *common
-  macos_bzlmods:
+  macos_bzlmod:
     name: Bzlmod macos
     platform: macos
     build_flags:
+    - "--enable_bzlmod"
+    test_flags:
     - "--enable_bzlmod"
     <<: *common
   macos_arm64_bzlmod:
     name: Bzlmod macos_arm64
     platform: macos_arm64
     build_flags:
+    - "--enable_bzlmod"
+    test_flags:
     - "--enable_bzlmod"
     <<: *common

--- a/kokoro/presubmit/presubmit_main.sh
+++ b/kokoro/presubmit/presubmit_main.sh
@@ -92,6 +92,7 @@ function main() {
     "--java_language_version=11"
     "--java_runtime_version=17"
     "--test_output=errors"
+    "--noenable_bzlmod"
   )
 
   # Go to rules_android workspace and run relevant tests.


### PR DESCRIPTION
Explicitly enable/disable bzlmod

enable_bzlmod now defaults to true at bazel HEAD, so we have to be careful about where specifically we want bzlmod enabled or disabled.

PiperOrigin-RevId: 574171623
Change-Id: I7143bba51b6304e9525e2b8d4aa7acf3173eec6d