### PR TITLE
Preserve order of android manifests when performing manifest merging

### DIFF
--- a/rules/busybox.bzl
+++ b/rules/busybox.bzl
@@ -778,15 +778,9 @@ def _escape_mv(s):
 def _owner_label(file):
     return "//" + file.owner.package + ":" + file.owner.name
 
-# We need to remove the "/_migrated/" path segment from file paths in order for sorting to
-# match the order of the native manifest merging action.
-def _manifest_short_path(manifest):
-    return manifest.short_path.replace("/_migrated/", "/")
-
 def _mergee_manifests_flag(manifests):
-    ordered_manifests = sorted(manifests.to_list(), key = _manifest_short_path)
     entries = []
-    for manifest in ordered_manifests:
+    for manifest in manifests:
         label = _owner_label(manifest).replace(":", "\\:")
         entries.append((manifest.path + ":" + label).replace(",", "\\,"))
     flag_entry = ",".join(entries)

--- a/rules/resources.bzl
+++ b/rules/resources.bzl
@@ -634,7 +634,7 @@ def _package(
         transitive_resource_apks.append(dep.transitive_resource_apks)
     mergee_manifests = depset([
         node_info.manifest
-        for node_info in depset(transitive = transitive_resources_nodes + direct_resources_nodes).to_list()
+        for node_info in depset(transitive = direct_resources_nodes + transitive_resources_nodes).to_list()
         if node_info.exports_manifest
     ])
 


### PR DESCRIPTION
Remove bogus code ordering manifest alphabetically. Changing order can possibly lead to incorrect output.
Direct dependencies' manifest should also take precendence on transitive deps.
