### PR TITLE
Respect the ordering of the manifests when merging

### DIFF
--- a/rules/android_binary_internal/attrs.bzl
+++ b/rules/android_binary_internal/attrs.bzl
@@ -166,6 +166,10 @@ ATTRS = _attrs.replace(
                 cfg = "exec",
                 executable = True,
             ),
+            _enable_manifest_merging_dependency_priorities = attr.label(
+                doc = """When enabled respect the manifest priorities during manifest merging.""",
+                default = "//rules/flags:enable_manifest_merging_dependency_priorities",
+            ),
         ),
         _attrs.COMPILATION,
         _attrs.DATA_CONTEXT,

--- a/rules/android_local_test/attrs.bzl
+++ b/rules/android_local_test/attrs.bzl
@@ -214,6 +214,10 @@ def make_attrs(additional_aspects = [], native_libs_transition = None):
                     Label("//tools/android:android_jar"),
                 ],
             ),
+            _enable_manifest_merging_dependency_priorities = attr.label(
+                doc = """When enabled respect the manifest priorities during manifest merging.""",
+                default = "//rules/flags:enable_manifest_merging_dependency_priorities",
+            ),
         ),
         _attrs.COMPILATION,
         _attrs.DATA_CONTEXT,

--- a/rules/flags/BUILD
+++ b/rules/flags/BUILD
@@ -3,7 +3,7 @@
 load("//rules/flags:flags.bzl", "flags")
 load("//rules/flags:flag_defs.bzl", "define_flags")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag")
 
 licenses(["notice"])
 
@@ -21,6 +21,12 @@ bzl_library(
 string_flag(
     name = "runfiles_root_prefix",
     build_setting_default = "rules_android/",
+    visibility = ["//visibility:public"],
+)
+
+bool_flag(
+    name = "enable_manifest_merging_dependency_priorities",
+    build_setting_default = False,
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Provide manifest in the same order as specified in deps in order to preserver priorities in the same spirit as gradle.

see https://github.com/bazelbuild/rules_android/issues/192