### PR TITLE
Fix: ProguardMapping is not queryable nor deterministically generated

### DIFF
--- a/rules/android_binary_internal/rule.bzl
+++ b/rules/android_binary_internal/rule.bzl
@@ -19,6 +19,7 @@ load(
     "//rules:attrs.bzl",
     _attrs = "attrs",
 )
+
 load(":attrs.bzl", "ATTRS")
 load(":impl.bzl", "impl")
 
@@ -52,6 +53,8 @@ def make_rule(
             "@bazel_tools//tools/jdk:toolchain_type",
         ] + additional_toolchains,
         _skylark_testable = True,
+        outputs = { 
+          "proguard_mapping" : "%{name}"  + "_proguard.map"},
         fragments = [
             "android",
             "java",


### PR DESCRIPTION
Fixing https://github.com/bazelbuild/rules_android/issues/194

The way to fix this is to explicitly declare the proguard mapping file. This will mean that the file will trigger a rebuild.

This fix may be incomplete though since this artifact may need to be declared as the input to the release target itself. If the proguard file changes then the proguarded build should be rebuilt as well.

Looking for comment/revision.