### PR TITLE
Add android_external in anticipation of dependency in @bazel_tools

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -100,7 +100,6 @@ tasks:
   ubuntu2004_basicapp:
     name: "Basic app ubuntu"
     platform: ubuntu2004
-    name: basicapp
     working_directory: examples/basicapp
     build_flags:
       <<: *rules_flags
@@ -109,7 +108,6 @@ tasks:
   ubuntu2004_basicapp_bzlmod:
     name: "Basic app ubuntu bzlmod"
     platform: ubuntu2004
-    name: basicapp
     working_directory: examples/basicapp
     build_flags:
       <<: *rules_flags
@@ -119,7 +117,6 @@ tasks:
   macos_arm64_basicapp:
     name: "Basic app mac arm64"
     platform: macos_arm64
-    name: basicapp
     working_directory: examples/basicapp
     build_flags:
       <<: *rules_flags
@@ -128,7 +125,6 @@ tasks:
   macos_arm64_basicapp_bzlmod:
     name: "Basic app mac arm64 bzlmod"
     platform: macos_arm64
-    name: basicapp
     working_directory: examples/basicapp
     build_flags:
       <<: *rules_flags

--- a/BUILD
+++ b/BUILD
@@ -53,3 +53,31 @@ platform(
             "@platforms//os:android",
         ],
 )
+
+# TODO: remove these alias when we no longer needs bind in WORKSPACE.bzlmod
+# Because @androidsdk is not defined in WORKSPACE.bzlmod, where the only valid place
+# we can call native function bind. Using these alias to forward the binding.
+alias(
+    name = "androidsdk_sdk",
+    actual = "@androidsdk//:sdk",
+)
+
+alias(
+    name = "androidsdk_d8_jar_import",
+    actual = "@androidsdk//:d8_jar_import",
+)
+
+alias(
+    name = "androidsdk_dx_jar_import",
+    actual = "@androidsdk//:dx_jar_import",
+)
+
+alias(
+    name = "androidsdk_files",
+    actual = "@androidsdk//:files",
+)
+
+alias(
+    name = "androidsdk_has_android_sdk",
+    actual = "@androidsdk//:has_android_sdk",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -99,3 +99,20 @@ git_override(
   remote = "https://github.com/robolectric/robolectric-bazel",
   commit = "a5b25a8c27cc6add74bb01e62cd0dc72df8933ff",
 )
+
+android_sdk_repository_extension = use_extension("//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
+use_repo(android_sdk_repository_extension, "androidsdk")
+
+register_toolchains(
+    "@androidsdk//:sdk-toolchain",
+    "@androidsdk//:all",
+)
+
+# In anticipation of @android_external dependency in @bazel_tools
+android_sdk_proxy_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "android_sdk_proxy_extensions")
+android_sdk_proxy_extensions.configure(
+    has_androidsdk = "@androidsdk//:has_androidsdk",
+    dx_jar_import = "@androidsdk//:dx_jar_import",
+    android_sdk_for_testing = "@androidsdk//:files",
+)
+use_repo(android_sdk_proxy_extensions, "android_external")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -22,6 +22,14 @@ load("defs_dev.bzl", "rules_android_workspace")
 
 rules_android_workspace()
 
+load("@bazel_tools//tools/android:android_extensions.bzl", "android_external_repository")
+android_external_repository(
+    name = "android_external",
+    has_androidsdk = "@androidsdk//:has_androidsdk",
+    dx_jar_import = "@androidsdk//:dx_jar_import",
+    android_sdk_for_testing = "@androidsdk//:files",
+)
+
 register_toolchains("//toolchains/android:all")
 
 register_toolchains("//toolchains/android_sdk:all")

--- a/WORKSPACE.bzlmod
+++ b/WORKSPACE.bzlmod
@@ -2,14 +2,15 @@ workspace(name = "rules_android")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("//rules:rules.bzl", "android_sdk_repository")
-
-maybe(
-    android_sdk_repository,
-    name = "androidsdk",
-)
 
 maybe(
     android_ndk_repository,
     name = "androidndk",
 )
+
+
+# TODO: remove bind when @bazel_tools//tools/android/... doesn't depends on //external
+bind(name = "android/sdk", actual = "//:androidsdk_sdk")
+bind(name = "android/dx_jar_import", actual = "//:androidsdk_dx_jar_import")
+bind(name = "android_sdk_for_testing", actual = "//:androidsdk_files")
+bind(name = "has_android_sdk", actual = "//:androidsdk_has_android_sdk")

--- a/examples/basicapp/MODULE.bazel
+++ b/examples/basicapp/MODULE.bazel
@@ -2,8 +2,30 @@ module(
     name = "basicapp",
 )
 
-# rules_android deps
-bazel_dep(name = "rules_jvm_external", version = "4.5")
-bazel_dep(name = "bazel_skylib", version = "1.3.0")
-remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
+bazel_dep(name = "rules_java", version = "7.4.0")
+bazel_dep(name = "bazel_skylib", version = "1.3.0") # Needed by bazel info
+
+# In anticipation of @android_external dependency in @bazel_tools
+android_sdk_proxy_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "android_sdk_proxy_extensions")
+android_sdk_proxy_extensions.configure(
+    has_androidsdk = "@androidsdk//:has_androidsdk",
+    dx_jar_import = "@androidsdk//:dx_jar_import",
+    android_sdk_for_testing = "@androidsdk//:files",
+)
+use_repo(android_sdk_proxy_extensions, "android_external")
+
+
+bazel_dep(
+    name = "rules_android",
+    version = "0.2.0",
+)
+
+local_path_override(
+    module_name = "rules_android",
+    path = "../../",
+)
+
+register_toolchains(
+    "@rules_android//toolchains/android:android_default_toolchain",
+    "@rules_android//toolchains/android_sdk:android_sdk_tools",
+)

--- a/examples/basicapp/WORKSPACE
+++ b/examples/basicapp/WORKSPACE
@@ -41,3 +41,10 @@ register_toolchains(
     "@rules_android//toolchains/android_sdk:android_sdk_tools",
 )
 
+load("@bazel_tools//tools/android:android_extensions.bzl", "android_external_repository")
+android_external_repository(
+    name = "android_external",
+    has_androidsdk = "@androidsdk//:has_androidsdk",
+    dx_jar_import = "@androidsdk//:dx_jar_import",
+    android_sdk_for_testing = "@androidsdk//:files",
+)

--- a/examples/basicapp/WORKSPACE.bzlmod
+++ b/examples/basicapp/WORKSPACE.bzlmod
@@ -1,21 +1,6 @@
-local_repository(
-    name = "rules_android",
-    path = "../..", # rules_android's WORKSPACE relative to this inner workspace
-)
-
-load("@rules_android//:prereqs.bzl", "rules_android_prereqs")
-rules_android_prereqs()
-load("@rules_android//:defs.bzl", "rules_android_workspace")
-rules_android_workspace()
+workspace(name = "basicapp")
 
 load("@rules_android//rules:rules.bzl", "android_sdk_repository")
 android_sdk_repository(
     name = "androidsdk",
 )
-
-register_toolchains(
-    "@rules_android//toolchains/android:android_default_toolchain",
-    "@rules_android//toolchains/android_sdk:android_sdk_tools",
-)
-
-

--- a/rules/android_sdk_repository/rule.bzl
+++ b/rules/android_sdk_repository/rule.bzl
@@ -209,3 +209,35 @@ def android_sdk_repository(
 
     native.register_toolchains("@%s//:sdk-toolchain" % name)
     native.register_toolchains("@%s//:all" % name)
+
+def _android_sdk_repository_extension_impl(module_ctx):
+    root_modules = [m for m in module_ctx.modules if m.is_root and m.tags.configure]
+    if len(root_modules) > 1:
+        fail("Expected at most one root module, found {}".format(", ".join([x.name for x in root_modules])))
+
+    if root_modules:
+        module = root_modules[0]
+    else:
+        module = module_ctx.modules[0]
+
+    kwargs = {}
+    if module.tags.configure:
+        kwargs["api_level"] = module.tags.configure[0].api_level
+        kwargs["build_tools_version"] = module.tags.configure[0].build_tools_version
+        kwargs["path"] = module.tags.configure[0].path
+
+    _android_sdk_repository(
+        name = "androidsdk",
+        **kwargs
+    )
+
+android_sdk_repository_extension = module_extension(
+    implementation = _android_sdk_repository_extension_impl,
+    tag_classes = {
+        "configure": tag_class(attrs = {
+            "path": attr.string(),
+            "api_level": attr.int(),
+            "build_tools_version": attr.string(),
+        }),
+    },
+)


### PR DESCRIPTION
To remove all //external:android<something> usages in `@bazel_tools`, all routing to `@androidsdk` will go through the new module `@android_external`. We have to add it to `@rules_android` before we can migrate `@bazel_tools`.

For backward compatibility, we can't remove all 'bind' calls until `@bazel_tools` is `//external`-free. Move bind calls to WORKSPACE.bzlmod because we can't have them stay in module extension implementation. It means the bind call happens before we have `@androidsdk` defined, so we add alias at top level to forward the binding to `@androidsdk`. However, `@rules_android~~android_sdk_repository_extension~androidsdk` is not visible from `//external:<blash>` when the root module is not `@rules_android`. So the example/basicapp still make direct android_sdk_repository call so its bind calls are in order.