### PR TITLE
Change databinding dependent lib artifact to a directory

### DIFF
--- a/rules/data_binding.bzl
+++ b/rules/data_binding.bzl
@@ -114,7 +114,7 @@ def _setup_dependent_lib_artifacts(ctx, output_dir, deps):
             path = artifact.short_path
             if path.startswith("../"):
                 path = path[3:]
-            dep_lib_artifact = ctx.actions.declare_file(
+            dep_lib_artifact = ctx.actions.declare_directory(
                 output_dir + "dependent-lib-artifacts/" + path,
             )
 


### PR DESCRIPTION
Dependent lib artifacts is supposed to be a directory but was registered as a `file`. This is an error in Bazel 7 due to `--incompatible_disallow_unsound_directory_outputs` which will be enforced in Bazel 8.

[Ref](https://github.com/bazelbuild/bazel/issues/22069#issuecomment-2068922121)
> Bazel needs to know whether an artifact is a file or a directory before its contents are produced, and coverage.dat is declared as a file. Before Bazel 7, producing a directory where a file is expected was tolerated, but broken in subtle ways. Bazel 7 forbids it by default (--incompatible_disallow_unsound_directory_outputs) and Bazel 8 will not allow it at all. 