### PR TITLE
Support overriding debuggable in AndroidManifest #13801

### DIFF
--- a/rules/flags/flags.bzl
+++ b/rules/flags/flags.bzl
@@ -91,12 +91,7 @@ def native_bool_flag_macro(name, description):
     )
 
 def _get_bool(v):
-    v = v.lower()
-    if v == "true":
-        return True
-    if v == "false":
-        return False
-    fail("Unknown bool: " + v)
+    return utils.get_bool(v)
 
 def _bool_impl(ctx):
     if ctx.label.name in ctx.var:

--- a/rules/resources.bzl
+++ b/rules/resources.bzl
@@ -747,6 +747,7 @@ def _package(
     resource_files_zip = ctx.actions.declare_file(
         "_migrated/" + ctx.label.name + "_files/resource_files.zip",
     )
+    debug = utils.get_bool(manifest_values["debuggable"]) if "debuggable" in manifest_values else None
     _busybox.package(
         ctx,
         out_file = resource_apk,
@@ -785,7 +786,7 @@ def _package(
         aapt = aapt,
         busybox = busybox,
         host_javabase = host_javabase,
-        debug = compilation_mode != _compilation_mode.OPT,
+        debug = compilation_mode != _compilation_mode.OPT if debug == None else debug,
         should_throw_on_conflict = should_throw_on_conflict,
     )
 

--- a/rules/utils.bzl
+++ b/rules/utils.bzl
@@ -441,6 +441,14 @@ def _get_compilation_mode(ctx):
     """
     return ctx.var["COMPILATION_MODE"]
 
+def _get_bool(v):
+    v = v.lower()
+    if v == "true":
+        return True
+    if v == "false":
+        return False
+    fail("Unknown bool: " + v)
+
 compilation_mode = struct(
     DBG = "dbg",
     FASTBUILD = "fastbuild",
@@ -466,6 +474,7 @@ utils = struct(
     list_or_depset_to_list = _list_or_depset_to_list,
     add_cls_prefix = _add_cls_prefix,
     get_cls = _get_cls,
+    get_bool = _get_bool
 )
 
 log = struct(


### PR DESCRIPTION
**Background**

Similar to https://github.com/bazelbuild/bazel/pull/13801, the only way to get a non debuggable-apk `debuggable="false"`  is to use --compilation-mode opt which will invalidate the entire dep graph.

**Changes**

The drawback of this diff is that unlike what exists in Bazel upstream, the source of truth for the "debuggable" flag of the AAPT2 command is not what is in the AndroidManifest.xml itself but whatever is in manifest_values in the BUILD file. 

If no value, we fallback to the compilation-mode opt behavior.

**Usage**
android_binary(
    name = "app",
    dex_shards = 10,
    manifest = "src/bazel/AndroidManifest.xml",
    manifest_values = {
        "minSdkVersion": "19",
        "appName": "...",
        "applicationId": "...",
        "debuggable": "false",
    },
    multidex = "native",
    visibility = ["//visibility:public"],
    deps = ["..."],
)