### PR TITLE
Golang cleanups

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,7 +29,7 @@ register_toolchains("//toolchains/android:all")
 register_toolchains("//toolchains/android_sdk:all")
 
 # go-related dependency setup
-bazel_dep(name = "rules_go", version = "0.43.0", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "rules_go", version = "0.48.0", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "gazelle", version = "0.28.0", repo_name = "bazel_gazelle")
 bazel_dep(name = "abseil-py", version = "1.4.0", repo_name = "py_absl")
 
@@ -55,7 +55,7 @@ python.toolchain(
 )
 
 # proto-related dependency setup
-bazel_dep(name = "rules_proto", version = "5.3.0-21.7", repo_name = "rules_proto")
+bazel_dep(name = "rules_proto", version = "6.0.0", repo_name = "rules_proto")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -35,6 +35,8 @@ bazel_dep(name = "abseil-py", version = "1.4.0", repo_name = "py_absl")
 
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 
+go_sdk.download(version = "1.22.4")
+
 go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
 go_deps.from_file(go_mod = "//:go.mod")
 use_repo(
@@ -133,4 +135,5 @@ git_override(
 
 android_sdk_repository_extension = use_extension("//rules/android_sdk_repository:rule.bzl", "android_sdk_repository_extension")
 use_repo(android_sdk_repository_extension, "androidsdk")
+
 register_toolchains("@androidsdk//:sdk-toolchain", "@androidsdk//:all")

--- a/defs.bzl
+++ b/defs.bzl
@@ -14,6 +14,7 @@
 
 """Workspace setup macro for rules_android."""
 
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
@@ -21,7 +22,8 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
 
 def rules_android_workspace():
@@ -76,8 +78,8 @@ def rules_android_workspace():
     go_repository(
         name = "org_golang_google_protobuf",
         importpath = "google.golang.org/protobuf",
-        sum = "h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=",
-        version = "v1.28.1",
+        sum = "h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=",
+        version = "v1.31.0",
     )
 
     go_repository(
@@ -105,6 +107,8 @@ def rules_android_workspace():
 
     rules_java_dependencies()
     rules_java_toolchains()
+
+    bazel_features_deps()
 
     rules_proto_dependencies()
     rules_proto_toolchains()

--- a/defs.bzl
+++ b/defs.bzl
@@ -18,7 +18,12 @@ load("@bazel_features//:deps.bzl", "bazel_features_deps")
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load(
+    "@io_bazel_rules_go//go:deps.bzl",
+    "go_download_sdk",
+    "go_register_toolchains",
+    "go_rules_dependencies",
+)
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
 load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
 load("@rules_jvm_external//:defs.bzl", "maven_install")
@@ -70,7 +75,9 @@ def rules_android_workspace():
 
     go_rules_dependencies()
 
-    go_register_toolchains(version = "1.20.5")
+    _GO_TOOLCHAIN_VERSION = "1.22.4"
+    go_download_sdk(name = "go_sdk", version = _GO_TOOLCHAIN_VERSION)
+    go_register_toolchains()
 
     gazelle_dependencies()
     # gazelle:repository go_repository name=org_golang_x_xerrors importpath=golang.org/x/xerrors

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,11 @@
 module github.com/bazelbuild/rules_android
 
-go 1.19
+go 1.21.1
 
 require (
-	github.com/google/go-cmp v0.5.9
+	github.com/bazelbuild/rules_go v0.48.0
 	github.com/golang/glog v1.1.2
+	github.com/google/go-cmp v0.5.9
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	google.golang.org/protobuf v1.28.1
+	google.golang.org/protobuf v1.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bazelbuild/rules_go v0.48.0 h1:fZgo6mCUKeL/+GQiMWy5/QU1FjNXGPnTd5bAeao1pbg=
+github.com/bazelbuild/rules_go v0.48.0/go.mod h1:Dhcz716Kqg1RHNWos+N6MlXNkjNP2EwZQ0LukRKJfMs=
 github.com/golang/glog v1.1.2 h1:DVjP2PbBOzHyzA+dn3WhHIq4NdVu3Q+pvivFICf/7fo=
 github.com/golang/glog v1.1.2/go.mod h1:zR+okUeTbrL6EL3xHUDxZuEtGv04p5shwip1+mL/rLQ=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -8,5 +10,5 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cO
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs8=
+google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=

--- a/prereqs.bzl
+++ b/prereqs.bzl
@@ -71,10 +71,10 @@ def rules_android_prereqs(dev_mode = False):
     maybe(
         http_archive,
         name = "io_bazel_rules_go",
-        sha256 = "51dc53293afe317d2696d4d6433a4c33feedb7748a9e352072e2ec3c0dafd2c6",
+        sha256 = "33acc4ae0f70502db4b893c9fc1dd7a9bf998c23e7ff2c4517741d4049a976f8",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.40.1/rules_go-v0.40.1.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.48.0/rules_go-v0.48.0.zip",
         ],
     )
 
@@ -118,14 +118,22 @@ def rules_android_prereqs(dev_mode = False):
         strip_prefix = "abseil-py-1.4.0",
     )
 
+    # Required by rules_proto.
+    maybe(
+        http_archive,
+        name = "bazel_features",
+        sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
+        strip_prefix = "bazel_features-1.9.1",
+        url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
+    )
+
+    # Required by rules_go.
     maybe(
         http_archive,
         name = "rules_proto",
-        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
-        strip_prefix = "rules_proto-5.3.0-21.7",
-        urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
-        ],
+        sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
+        strip_prefix = "rules_proto-6.0.0",
+        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
     )
 
     maybe(


### PR DESCRIPTION
    * Make bzlmod and WORKSPACE use the same rules_go version
    * Run `go mod tidy`
    * Update protobuf golang repo version
    * Use the same SDK version for WORKSPACE and bzlmod