### PR TITLE
Update r8.bzl to return AndroidPreDexJarInfo

### DIFF
--- a/rules/android_binary_internal/r8.bzl
+++ b/rules/android_binary_internal/r8.bzl
@@ -22,7 +22,7 @@ load(
     "ProviderInfo",
 )
 load("//rules:proguard.bzl", "proguard")
-load("//rules:providers.bzl", "AndroidApplicationResourceInfo", "AndroidDexInfo")
+load("//rules:providers.bzl", "AndroidApplicationResourceInfo", "AndroidDexInfo", "AndroidPreDexJarInfo")
 load("//rules:resources.bzl", _resources = "resources")
 load(
     "//rules:utils.bzl",

--- a/rules/android_binary_internal/r8.bzl
+++ b/rules/android_binary_internal/r8.bzl
@@ -119,7 +119,10 @@ def process_r8(ctx, validation_ctx, jvm_ctx, packaged_resources_ctx, build_info_
         value = struct(
             final_classes_dex_zip = dexes_zip,
             dex_info = android_dex_info,
-            providers = [android_dex_info],
+            providers = [
+                android_dex_info,
+                AndroidPreDexJarInfo(deploy_jar),
+            ],
         ),
     )
 


### PR DESCRIPTION
This provider is missing on the android_binary target when R8 is enabled which is needed later by the application.bzl rule.

```
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/rules_android~/rules/android_application/android_application_rule.bzl", line 387, column 29, in _impl
                ctx.attr.base_module[AndroidPreDexJarInfo],
Error: <target //apps/rider:bin_devRelease> (rule 'android_binary') doesn't contain declared provider 'AndroidPreDexJarInfo'
```