### PR TITLE
Pass tags to android_application

### DIFF
--- a/rules/android_application/android_application_rule.bzl
+++ b/rules/android_application/android_application_rule.bzl
@@ -491,4 +491,5 @@ def android_application_macro(_android_binary, **attrs):
         sdk_bundles = sdk_bundles,
         manifest_values = attrs.get("manifest_values"),
         visibility = attrs.get("visibility", None),
+        tags = attrs.get("tags", []),
     )


### PR DESCRIPTION
Ensures that the tags are applied to both the android_application and android_binary targets.