### PR TITLE
Add better support for Kotlin test coverage

### DIFF
--- a/rules/android_library/impl.bzl
+++ b/rules/android_library/impl.bzl
@@ -445,7 +445,7 @@ def _process_coverage(ctx, **unused_ctx):
                 coverage_common.instrumented_files_info(
                     ctx,
                     source_attributes = ["srcs"],
-                    dependency_attributes = ["assets", "deps", "exports"],
+                    dependency_attributes = ["associates", "assets", "deps", "exports"],
                 ),
             ],
         ),

--- a/rules/android_local_test/impl.bzl
+++ b/rules/android_local_test/impl.bzl
@@ -383,7 +383,7 @@ def finalize(
         coverage_common.instrumented_files_info(
             ctx = ctx,
             source_attributes = ["srcs"],
-            dependency_attributes = ["deps", "runtime_deps", "data"],
+            dependency_attributes = ["associates", "deps", "runtime_deps", "data"],
         ),
     ])
     return providers


### PR DESCRIPTION
The Kotlin compiler supports associated dependencies (or friends). Without this attribute being explicitly included in the instrumentation provider, Bazel crashes during setup due to duplicate `baseline_coverage.dat` files are being created for the same target.