### PR TITLE
Update `rules_java` `v7.11.1`

### DIFF
--- a/prereqs.bzl
+++ b/prereqs.bzl
@@ -23,9 +23,9 @@ def rules_android_prereqs(dev_mode = False):
         http_archive,
         name = "rules_java",
         urls = [
-            "https://github.com/bazelbuild/rules_java/releases/download/7.7.0/rules_java-7.7.0.tar.gz",
+            "https://github.com/bazelbuild/rules_java/releases/download/7.11.1/rules_java-7.11.1.tar.gz",
         ],
-        sha256 = "790d1ab5c75a6236b2ceaef01f50687a9d18a219aaff70865cb20326cb50bbc2",
+        sha256 = "6f3ce0e9fba979a844faba2d60467843fbf5191d8ca61fa3d2ea17655b56bb8c",
     )
 
     RULES_JVM_EXTERNAL_TAG = "6.2"

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -303,7 +303,7 @@ filegroup(
 run_singlejar(
     name = "gen_java_base_extras_jar",
     srcs = [
-        "@bazel_tools//tools/jdk:platformclasspath",
+        "@rules_java//toolchains:platformclasspath",
     ],
     out = "java_base_extras.jar",
     include_prefixes = [

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -1,4 +1,4 @@
-load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+load("@rules_java//toolchains:default_java_toolchain.bzl", "default_java_toolchain")
 
 default_java_toolchain(
     name = "toolchain_android_only",
@@ -12,19 +12,19 @@ default_java_toolchain(
 
 alias(
     name = "toolchain",
-    actual = "@bazel_tools//tools/jdk:toolchain",
+    actual = "@rules_java//toolchains:toolchain",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "current_java_runtime",
-    actual = "@bazel_tools//tools/jdk:current_java_runtime",
+    actual = "@rules_java//toolchains:current_java_runtime",
     visibility = ["//visibility:public"],
 )
 
 alias(
     name = "current_java_toolchain",
-    actual = "@bazel_tools//tools/jdk:current_java_toolchain",
+    actual = "@rules_java//toolchains:current_java_toolchain",
     visibility = ["//visibility:public"],
 )
 
@@ -36,6 +36,6 @@ alias(
 
 alias(
     name = "current_host_java_runtime",
-    actual = "@bazel_tools//tools/jdk:current_host_java_runtime",
+    actual = "@rules_java//toolchains:current_host_java_runtime",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Also start migrating jdk toolchain/runtime references away from `@bazel_tools` (those use an embedded version of rules_java which will be dropped when WORKSPACE support is dropped, likely soon after Bazel 8 is cut)