### PR TITLE
feat: add skylib-gazelle compatible target for `//android/rules.bzl`

### DIFF
--- a/android/BUILD
+++ b/android/BUILD
@@ -16,3 +16,16 @@
 Package used for redirecting Starlark rules from //android/rules.bzl to //rules/rules.bzl.
 Used for easier migration to a new branch due to directory differences.
 """
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "rules",
+    srcs = ["rules.bzl"],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//rules:bzl",
+    ],
+)

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -96,6 +96,7 @@ bzl_library(
         "rules.bzl",
     ],
     visibility = [
+        "//android:__pkg__",
         "//mobile_install:__pkg__",
         "//stardoc:__pkg__",
         "//test/rules/android_sdk_repository:__pkg__",


### PR DESCRIPTION
This adds a `bzl_library` target for `//android/rules.bzl` which should match the expected target name when using [`bazelbuild/bazel-skylib`'s gazelle plugin](https://registry.bazel.build/modules/bazel_skylib_gazelle_plugin). Without this, users of the plugin who also depend on these rules will need to manually adjust their configuration.