### PR TITLE
Support relative workspace paths

### DIFF
--- a/rules/android_sdk_repository/rule.bzl
+++ b/rules/android_sdk_repository/rule.bzl
@@ -96,6 +96,8 @@ def _android_sdk_repository_impl(repo_ctx):
     android_sdk_path = repo_ctx.attr.path
     if not android_sdk_path:
         android_sdk_path = repo_ctx.os.environ.get("ANDROID_HOME")
+        if android_sdk_path.startswith("$WORKSPACE_ROOT"):
+            android_sdk_path = str(ctx.workspace_root) + android_sdk_path.removeprefix("$WORKSPACE_ROOT")
     if not android_sdk_path:
         # Create an empty repository that allows non-Android code to build.
         repo_ctx.template("BUILD.bazel", _EMPTY_SDK_REPO_TEMPLATE)


### PR DESCRIPTION
Make it possible for the Android SDK path to exist within the workspace when using the ANDROID_HOME repository environment variable. This is similar to https://github.com/bazelbuild/rules_android_ndk/pull/69 which added the same behavior to rules_android_ndk