### PR TITLE
Handle --logWarnings in AndroidAssetMergingAction

### DIFF
--- a/src/tools/java/com/google/devtools/build/android/AndroidAssetMergingAction.java
+++ b/src/tools/java/com/google/devtools/build/android/AndroidAssetMergingAction.java
@@ -43,7 +43,8 @@ public class AndroidAssetMergingAction extends AbstractBusyBoxAction {
 
   private static AndroidAssetMergingAction create() {
     Options options = new Options();
-    JCommander jc = new JCommander(options);
+    Object[] allOptions = new Object[] {options, new ResourceProcessorCommonOptions()};
+    JCommander jc = new JCommander(allOptions);
     return new AndroidAssetMergingAction(jc);
   }
 


### PR DESCRIPTION
`AndroidAssetMergingAction` is currently broken when workers are enabled because it's not handles the `--logWarnings` arguments being added by `_set_warning_level` https://github.com/bazelbuild/rules_android/blob/b105d007f21cedaa5b52911d5c27ebd3f871433a/rules/busybox.bzl#L134-L138

The error:
```console
Dec 04, 2024 6:57:12 PM com.google.devtools.build.android.AbstractBusyBoxAction invoke
SEVERE: Was passed main parameter '--logWarnings=false' but no main parameter was defined in your arg class
```