### PR TITLE
Pass build_target to singlejar when extracting aar contents

### DIFF
--- a/rules/aar_import/impl.bzl
+++ b/rules/aar_import/impl.bzl
@@ -192,6 +192,7 @@ def _extract_jars(
     args = ctx.actions.args()
     args.add("--input_aar", aar)
     args.add("--output_dir", out_jars_tree_artifact.path)
+    args.add("--build_target", ctx.label)
     args.add("--output_singlejar_param_file", out_jars_params_file)
     ctx.actions.run(
         executable = aar_embedded_jars_extractor_tool,

--- a/tools/android/aar_embedded_jars_extractor_test.py
+++ b/tools/android/aar_embedded_jars_extractor_test.py
@@ -54,12 +54,14 @@ class AarEmbeddedJarsExtractor(unittest.TestCase):
     aar.writestr("libs/b.jar", "")
     param_file = io.BytesIO()
     os.makedirs("out_dir")
-    aar_embedded_jars_extractor.ExtractEmbeddedJars(aar, param_file, "out_dir")
+    aar_embedded_jars_extractor.ExtractEmbeddedJars(aar, param_file, "out_dir", "//foo:bar")
     self.assertCountEqual(["classes.jar", "libs"], os.listdir("out_dir"))
     self.assertCountEqual(["a.jar", "b.jar"], os.listdir("out_dir/libs"))
     param_file.seek(0)
     self.assertEqual(
         [b"--exclude_build_data\n",
+         b"--build_target\n",
+         b"//foo:bar\n",
          b"--sources\n",
          b"out_dir/classes.jar\n",
          b"--sources\n",
@@ -73,11 +75,13 @@ class AarEmbeddedJarsExtractor(unittest.TestCase):
     aar.writestr("classes.jar", "")
     param_file = io.BytesIO()
     os.makedirs("out_dir")
-    aar_embedded_jars_extractor.ExtractEmbeddedJars(aar, param_file, "out_dir")
+    aar_embedded_jars_extractor.ExtractEmbeddedJars(aar, param_file, "out_dir", "//foo:bar")
     self.assertEqual(["classes.jar"], os.listdir("out_dir"))
     param_file.seek(0)
     self.assertEqual(
         [b"--exclude_build_data\n",
+         b"--build_target\n",
+         b"//foo:bar\n",
          b"--sources\n",
          b"out_dir/classes.jar\n"],
         param_file.readlines())


### PR DESCRIPTION
Passes the `build_target` argument to singlejar so that the extracted/merged jars can be associated with the original aar that created them.