### PR TITLE
Make providers_bzl public

### DIFF
--- a/providers/BUILD
+++ b/providers/BUILD
@@ -5,6 +5,6 @@ bzl_library(
     srcs = [
         "providers.bzl",
     ],
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
     deps = ["//rules:visibility_bzl"],
 )


### PR DESCRIPTION
External rules can't depend on these providers in their `bzl_library` if this is kept private to subpackages.