### PR TITLE
Adding support for ABIs for AARs

### DIFF
--- a/rules/aar_import/impl.bzl
+++ b/rules/aar_import/impl.bzl
@@ -345,14 +345,22 @@ def _process_jars(
     if enable_imports_deps_check:
         validation_results.append(jdeps_artifact)
 
+    stamp_jar = java_common.stamp_jar(
+                actions = ctx.actions,
+                jar = out_jar,
+                target_label = ctx.label,
+                java_toolchain = java_toolchain,
+            )
+    java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo]
+    compile_jar = java_common.run_ijar(
+        actions = ctx.actions,
+        jar = stamp_jar,
+        target_label = ctx.label,
+        java_toolchain = java_toolchain,
+    )
     java_info = JavaInfo(
         out_jar,
-        compile_jar = java_common.stamp_jar(
-            actions = ctx.actions,
-            jar = out_jar,
-            target_label = ctx.label,
-            java_toolchain = java_toolchain,
-        ),
+        compile_jar = compile_jar,
         source_jar = source_jar,
         neverlink = False,
         deps = r_java_info + java_infos,  # TODO(djwhang): Exports are not deps.


### PR DESCRIPTION
AARs are directly listed as compile jars. This diff creates iJars using rules_java's native ijar creation and supplies them as compile jars to the info providers.

This allows for less memory consumption when loading them into the classpath and actions and speeds up build times.