### PR TITLE
Fix: pass adb path to mobile-install launcher and canonicalize

### DIFF
--- a/src/tools/mi/deployment_oss/deploy_binary.go
+++ b/src/tools/mi/deployment_oss/deploy_binary.go
@@ -22,6 +22,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -118,6 +119,18 @@ func main() {
 	ctx := context.Background()
 
 	flag.Parse()
+
+	var (
+		realPath string
+		err      error
+	)
+	if realPath, err = filepath.EvalSymlinks(*adbPath); err != nil {
+		glog.Exitf("Unable to dereference adb path: %s", err.Error())
+	}
+	if realPath, err = filepath.Abs(realPath); err != nil {
+		glog.Exitf("Unable to canonicalize adb path: %s", err.Error())
+	}
+	*adbPath = realPath
 
 	pprint.Info("Deploying using OSS mobile-install!")
 


### PR DESCRIPTION
Path to `adb` was not being sent to MI launcher. This caused it to use the default `/usr/bin/adb`, which is not always valid.

Fixes #349