### PR TITLE
Keep META-INF/*.version files to support AS Layout Inspector

### DIFF
--- a/src/tools/java_resource_extractor/resource_extractor.py
+++ b/src/tools/java_resource_extractor/resource_extractor.py
@@ -86,7 +86,10 @@ def IsValidPath(path):
   # allow META-INF/services at the root to support ServiceLoader
   if dirs[:2] == ['meta-inf', 'services']:
     return True
-
+  # allow META-INF/*.version files to support AS Layout Inspector
+  if dirs[:1] == ['meta-inf'] and filename.endswith('.version'):
+    return True
+    
   return not any(dir in EXCLUDED_DIRECTORIES for dir in dirs)
 
 


### PR DESCRIPTION
### What has changed?
- Prevented `resource_extractor.py` from removing `.version` files from `META-INF`

### Why it was changed?
- These files are required for layout inspector to work with Compose. See [docs](https://developer.android.com/develop/ui/compose/tooling/layout-inspector): 
![image](https://ghe.spotify.net/storage/user/7383/files/246a1e24-c757-4e6e-9a74-9bc456776734)