### PR TITLE
Add filesgroups for all packages

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -127,6 +127,7 @@ tasks:
     build_flags:
       <<: *rules_flags
     build_targets:
+      - "//:examples_basicapp_all_files_tar"
       - "//java/com/basicapp:basic_app"
   ubuntu2004_basicapp_bzlmod:
     name: "Basic app ubuntu bzlmod"
@@ -138,6 +139,7 @@ tasks:
       ? "--enable_bzlmod"
       ? "--enable_workspace=false"
     build_targets:
+      - "//:examples_basicapp_all_files_tar"
       - "//java/com/basicapp:basic_app"
   macos_arm64_basicapp:
     name: "Basic app mac arm64"
@@ -147,6 +149,7 @@ tasks:
     build_flags:
       <<: *rules_flags
     build_targets:
+      - "//:examples_basicapp_all_files_tar"
       - "//java/com/basicapp:basic_app"
   macos_arm64_basicapp_bzlmod:
     name: "Basic app mac arm64 bzlmod"
@@ -158,6 +161,7 @@ tasks:
       ? "--enable_bzlmod"
       ? "--enable_workspace=false"
     build_targets:
+      - "//:examples_basicapp_all_files_tar"
       - "//java/com/basicapp:basic_app"
   windows_basicapp_bzlmod:
     name: "Windows Basicapp Bzlmod"
@@ -169,6 +173,7 @@ tasks:
       ? "--enable_bzlmod"
       ? "--enable_workspace=false"
     build_targets:
+      - "//:examples_basicapp_all_files_tar"
       - "//java/com/basicapp:basic_app"
   windows_basicapp:
     name: "Windows Basicapp"
@@ -178,4 +183,5 @@ tasks:
     build_flags:
       <<: *rules_flags
     build_targets:
+      - "//:examples_basicapp_all_files_tar"
       - "//java/com/basicapp:basic_app"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,7 +19,7 @@ rules_flags: &rules_flags
 tools: &tools
   name: "Tools"
   build_targets:
-    - "//:all_files_tar",
+    - "//:all_files_tar"
     - "//android/..."
     - "//src/..."
     - "-//src/java/com/example/sampleapp/..."

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -19,6 +19,7 @@ rules_flags: &rules_flags
 tools: &tools
   name: "Tools"
   build_targets:
+    - "//:all_files_tar",
     - "//android/..."
     - "//src/..."
     - "-//src/java/com/example/sampleapp/..."

--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@rules_license//rules:license.bzl", "license")
 
 package(
-    default_applicable_licenses = [":license"],
+    default_applicable_licenses = ["//:license"],
     default_visibility = ["//visibility:public"],
 )
 
@@ -89,4 +89,43 @@ alias(
 alias(
     name = "androidsdk_has_android_sdk",
     actual = "@androidsdk//:has_android_sdk",
+)
+
+filegroup(
+    name = "all_files",
+    # Note: The glob pattern here is just '*' and not '**' in order to avoid collecing subdirectories
+    # In OSS Bazel-land, subdirectories can include irrelevant files such as .git/, .bazelci/, etc.
+    srcs = glob(["*"]) + [
+        "//android:all_files",
+        "//bzlmod_extensions:all_files",
+        "//mobile_install:all_files",
+        "//providers:all_files",
+        "//rules:all_files",
+        "//src/common/golang:all_files",
+        "//src/tools/ak:all_files",
+        "//src/tools/bundletool_module_builder:all_files",
+        "//src/tools/deploy_info:all_files",
+        "//src/tools/extract_desugar_pgcfg_flags:all_files",
+        "//src/tools/jar_to_module_info:all_files",
+        "//src/tools/java/com/google/devtools/build/android:srcs",
+        "//src/tools/java_resource_extractor:all_files",
+        "//src/tools/jdeps:all_files",
+        "//src/tools/mi/deployment_oss:all_files",
+        "//src/tools/split_core_jar:all_files",
+        "//src/validations/aar_import_checks:all_files",
+        "//src/validations/validate_manifest:all_files",
+        "//toolchains/android:all_files",
+        "//toolchains/android_sdk:all_files",
+        "//tools/android:all_files",
+        "//tools/jdk:all_files",
+    ]
+)
+
+genrule(
+    name = "all_files_tar",
+    srcs = [":all_files"],
+    outs = ["all_files.tar"],
+    # Note: The "h" in the tar options forces tar to _copy_ the files into
+    # the archive, rather than symlink.
+    cmd = "tar chf $@ $(locations :all_files)",
 )

--- a/android/BUILD
+++ b/android/BUILD
@@ -16,3 +16,9 @@
 Package used for redirecting Starlark rules from //android/rules.bzl to //rules/rules.bzl.
 Used for easier migration to a new branch due to directory differences.
 """
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)

--- a/bzlmod_extensions/BUILD
+++ b/bzlmod_extensions/BUILD
@@ -1,3 +1,9 @@
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 exports_files(
     [
         "apksig.BUILD",

--- a/examples/basicapp/BUILD
+++ b/examples/basicapp/BUILD
@@ -1,1 +1,13 @@
-# Empty build file to satisfy gazelle for rules_go.
+filegroup(
+    name = "all_files",
+    srcs = glob(["*"]) + [
+        "//java/com/basicapp:all_files",
+    ],
+)
+
+genrule(
+    name = "examples_basicapp_all_files_tar",
+    srcs = [":all_files"],
+    outs = ["examples_basicapp_all_files.tar"],
+    cmd = "tar chf $@ $(locations :all_files) --transform 's,^,examples/basicapp/,'",
+)

--- a/examples/basicapp/BUILD
+++ b/examples/basicapp/BUILD
@@ -9,5 +9,5 @@ genrule(
     name = "examples_basicapp_all_files_tar",
     srcs = [":all_files"],
     outs = ["examples_basicapp_all_files.tar"],
-    cmd = "tar chf $@ $(locations :all_files) --transform 's,^,examples/basicapp/,'",
+    cmd = "tar chf $@ $(locations :all_files)",
 )

--- a/examples/basicapp/java/com/basicapp/BUILD
+++ b/examples/basicapp/java/com/basicapp/BUILD
@@ -13,3 +13,10 @@ android_library(
     manifest = "AndroidManifest.xml",
     resource_files = glob(["res/**"]),
 )
+
+# For integration testing.
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)

--- a/providers/BUILD
+++ b/providers/BUILD
@@ -1,5 +1,11 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 bzl_library(
     name = "providers_bzl",
     srcs = [

--- a/rules/BUILD
+++ b/rules/BUILD
@@ -2,6 +2,10 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "int_setting")
 load("@rules_java//java:defs.bzl", "java_library")
 
+package(
+    default_applicable_licenses = ["//:license"],
+)
+
 exports_files([
     "data_binding_annotation_template.txt",
     "res_v3_dummy_AndroidManifest.xml",
@@ -146,4 +150,21 @@ int_setting(
 java_library(
     name = "aidl_lib",
     visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]) + [
+        "//rules/aar_import:all_files",
+        "//rules/acls:all_files",
+        "//rules/android_application:all_files",
+        "//rules/android_binary:all_files",
+        "//rules/android_common:all_files",
+        "//rules/android_library:all_files",
+        "//rules/android_local_test:all_files",
+        "//rules/android_sandboxed_sdk:all_files",
+        "//rules/android_sdk_repository:all_files",
+        "//rules/flags:all_files",
+    ],
+    visibility = ["//:__pkg__"],
 )

--- a/rules/aar_import/BUILD
+++ b/rules/aar_import/BUILD
@@ -2,13 +2,16 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-licenses(["notice"])
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 exports_files(["rule.bzl"])
 
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
 )
 
 bzl_library(

--- a/rules/acls/BUILD
+++ b/rules/acls/BUILD
@@ -1,5 +1,15 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+package(
+    default_applicable_licenses = ["//:license"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
+)
+
 bzl_library(
     name = "bzl",
     srcs = glob(["*.bzl"]),

--- a/rules/android_application/BUILD
+++ b/rules/android_application/BUILD
@@ -3,7 +3,9 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 
-licenses(["notice"])
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 exports_files([
     "bundle_deploy.sh_template",
@@ -16,6 +18,7 @@ exports_files([
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
 )
 
 bzl_library(

--- a/rules/android_binary/BUILD
+++ b/rules/android_binary/BUILD
@@ -2,11 +2,14 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-licenses(["notice"])
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
 )
 
 bzl_library(

--- a/rules/android_library/BUILD
+++ b/rules/android_library/BUILD
@@ -2,13 +2,16 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-licenses(["notice"])
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 exports_files(["rule.bzl"])
 
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
 )
 
 bzl_library(

--- a/rules/android_sandboxed_sdk/BUILD
+++ b/rules/android_sandboxed_sdk/BUILD
@@ -2,7 +2,9 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-licenses(["notice"])
+package(
+    default_applicable_licenses = ["//:license"],
+)
 
 exports_files([
     "android_sandboxed_sdk.bzl",
@@ -12,6 +14,7 @@ exports_files([
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
 )
 
 bzl_library(

--- a/rules/android_sdk_repository/BUILD
+++ b/rules/android_sdk_repository/BUILD
@@ -3,6 +3,16 @@
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
+package(
+    default_applicable_licenses = ["//:license"],
+)
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
+)
+
 bzl_library(
     name = "bzl",
     srcs = [

--- a/rules/flags/BUILD
+++ b/rules/flags/BUILD
@@ -9,9 +9,14 @@ load("//rules/flags:flags.bzl", "flags")
 
 licenses(["notice"])
 
+package(
+    default_applicable_licenses = ["//:license"],
+)
+
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//rules:__pkg__"]
 )
 
 bzl_library(

--- a/src/common/golang/BUILD
+++ b/src/common/golang/BUILD
@@ -9,6 +9,12 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 licenses(["notice"])
 
 go_library(

--- a/src/tools/ak/BUILD
+++ b/src/tools/ak/BUILD
@@ -11,6 +11,30 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]) + [
+        "//src/tools/ak/bucketize:all_files",
+        "//src/tools/ak/compile:all_files",
+        "//src/tools/ak/dex:all_files",
+        "//src/tools/ak/extractaar:all_files",
+        "//src/tools/ak/extractresources:all_files",
+        "//src/tools/ak/finalrjar:all_files",
+        "//src/tools/ak/generatemanifest:all_files",
+        "//src/tools/ak/link:all_files",
+        "//src/tools/ak/liteparse:all_files",
+        "//src/tools/ak/manifest:all_files",
+        "//src/tools/ak/minsdkfloor:all_files",
+        "//src/tools/ak/nativelib:all_files",
+        "//src/tools/ak/patch:all_files",
+        "//src/tools/ak/proto:all_files",
+        "//src/tools/ak/repack:all_files",
+        "//src/tools/ak/res:all_files",
+        "//src/tools/ak/rjar:all_files",
+    ],
+    visibility = ["//:__pkg__"]
+)
+
 go_binary(
     name = "ak",
     srcs = [

--- a/src/tools/ak/bucketize/BUILD
+++ b/src/tools/ak/bucketize/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "bucketize_bin",
     srcs = ["bucketize_bin.go"],

--- a/src/tools/ak/compile/BUILD
+++ b/src/tools/ak/compile/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "compile_bin",
     srcs = ["compile_bin.go"],

--- a/src/tools/ak/dex/BUILD
+++ b/src/tools/ak/dex/BUILD
@@ -10,6 +10,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "dex_bin",
     srcs = ["dex_bin.go"],

--- a/src/tools/ak/extractaar/BUILD
+++ b/src/tools/ak/extractaar/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "extractaar",
     srcs = [

--- a/src/tools/ak/extractresources/BUILD
+++ b/src/tools/ak/extractresources/BUILD
@@ -9,6 +9,12 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "extractresources",
     srcs = ["extractresources.go"],

--- a/src/tools/ak/finalrjar/BUILD
+++ b/src/tools/ak/finalrjar/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "finalrjar",
     srcs = ["finalrjar.go"],

--- a/src/tools/ak/generatemanifest/BUILD
+++ b/src/tools/ak/generatemanifest/BUILD
@@ -10,6 +10,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "generatemanifest_bin",
     srcs = ["generatemanifest_bin.go"],

--- a/src/tools/ak/link/BUILD
+++ b/src/tools/ak/link/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "link_bin",
     srcs = ["link_bin.go"],

--- a/src/tools/ak/liteparse/BUILD
+++ b/src/tools/ak/liteparse/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "liteparse",
     srcs = [

--- a/src/tools/ak/manifest/BUILD
+++ b/src/tools/ak/manifest/BUILD
@@ -10,6 +10,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "manifest_bin",
     srcs = ["manifest_bin.go"],

--- a/src/tools/ak/minsdkfloor/BUILD
+++ b/src/tools/ak/minsdkfloor/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "minsdkfloor",
     srcs = ["minsdkfloor.go"],

--- a/src/tools/ak/nativelib/BUILD
+++ b/src/tools/ak/nativelib/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "nativelib",
     srcs = ["nativelib.go"],

--- a/src/tools/ak/patch/BUILD
+++ b/src/tools/ak/patch/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "patch_bin",
     srcs = ["patch_bin.go"],

--- a/src/tools/ak/proto/BUILD
+++ b/src/tools/ak/proto/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 proto_library(
     name = "sync_proto",
     srcs = ["sync.proto"],

--- a/src/tools/ak/repack/BUILD
+++ b/src/tools/ak/repack/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_binary(
     name = "repack_bin",
     srcs = ["repack_bin.go"],

--- a/src/tools/ak/res/BUILD
+++ b/src/tools/ak/res/BUILD
@@ -11,6 +11,16 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]) + [
+        "//src/tools/ak/res/proto:all_files",
+        "//src/tools/ak/res/respipe:all_files",
+        "//src/tools/ak/res/resxml:all_files",
+    ],
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "res",
     srcs = [

--- a/src/tools/ak/res/proto/BUILD
+++ b/src/tools/ak/res/proto/BUILD
@@ -12,6 +12,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak/res:__pkg__"],
+)
+
 proto_library(
     name = "res_meta_proto",
     srcs = ["res_meta.proto"],

--- a/src/tools/ak/res/respipe/BUILD
+++ b/src/tools/ak/res/respipe/BUILD
@@ -5,6 +5,12 @@ package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak/res:__pkg__"],
+)
+
 go_library(
     name = "respipe",
     srcs = [

--- a/src/tools/ak/res/resxml/BUILD
+++ b/src/tools/ak/res/resxml/BUILD
@@ -5,6 +5,12 @@ package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak/res:__pkg__"],
+)
+
 go_library(
     name = "resxml",
     srcs = ["xml_parser.go"],

--- a/src/tools/ak/rjar/BUILD
+++ b/src/tools/ak/rjar/BUILD
@@ -11,6 +11,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/ak:__pkg__"],
+)
+
 go_library(
     name = "rjar",
     srcs = ["rjar.go"],

--- a/src/tools/bundletool_module_builder/BUILD
+++ b/src/tools/bundletool_module_builder/BUILD
@@ -8,6 +8,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"]
+)
+
 go_binary(
     name = "bundletool_module_builder",
     srcs = ["bundletool_module_builder.go"],

--- a/src/tools/deploy_info/BUILD
+++ b/src/tools/deploy_info/BUILD
@@ -5,6 +5,14 @@ package(default_applicable_licenses = ["//:license"])
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]) + [
+        "//src/tools/deploy_info/proto:all_files",
+    ],
+    visibility = ["//:__pkg__"],
+)
+
 DEPLOY_INFO_VISIBILITY_GOOGLE3 = [
     "//mobile_install:__subpackages__",
     "//test/mobile_install:__subpackages__",

--- a/src/tools/deploy_info/proto/BUILD
+++ b/src/tools/deploy_info/proto/BUILD
@@ -3,6 +3,12 @@ load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/deploy_info:__pkg__"],
+)
+
 proto_library(
     name = "android_deploy_info_proto",
     srcs = ["android_deploy_info.proto"],

--- a/src/tools/extract_desugar_pgcfg_flags/BUILD
+++ b/src/tools/extract_desugar_pgcfg_flags/BUILD
@@ -10,6 +10,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 go_binary(
     name = "extract_desugar_pgcfg_flags",
     srcs = ["extract_desugar_pgcfg_flags.go"],

--- a/src/tools/jar_to_module_info/BUILD
+++ b/src/tools/jar_to_module_info/BUILD
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 go_binary(
     name = "jar_to_module_info",
     embed = [":jar_to_module_info_lib"],

--- a/src/tools/java/com/google/devtools/build/android/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/BUILD
@@ -5,6 +5,22 @@ load("//tools/android:defs.bzl", "run_singlejar")
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]) + [
+        "//src/tools/java/com/google/devtools/build/android/desugar:srcs",
+        "//src/tools/java/com/google/devtools/build/android/dexer:srcs",
+        "//src/tools/java/com/google/devtools/build/android/idlclass:srcs",
+        "//src/tools/java/com/google/devtools/build/android/junctions:srcs",
+        "//src/tools/java/com/google/devtools/build/android/proto:srcs",
+        "//src/tools/java/com/google/devtools/build/android/r8:srcs",
+        "//src/tools/java/com/google/devtools/build/android/resources:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:srcs",
+        "//src/tools/java/com/google/devtools/build/android/ziputils:srcs",
+    ],
+    visibility = ["//:__pkg__"],
+)
+
 # Used by //src/test/shell/bazel/android:android_integration_test
 java_binary(
     name = "ResourceProcessorBusyBox",

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/BUILD
@@ -11,6 +11,22 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]) + [
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/apidescriptors:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/clientsources:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/info:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/mixin:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/proguardspecs:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/runtimeenabledsdkconfig:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/sdkdependenciesmanifest:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/sdksplitproperties:srcs",
+        "//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/validatemodulesconfig:srcs",
+    ],
+    visibility = ["//src/tools/java/com/google/devtools/build/android:__pkg__"]
+)
+
 java_library(
     name = "sandboxed_sdk_toolbox_lib",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/apidescriptors/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/apidescriptors/BUILD
@@ -9,6 +9,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "apidescriptors",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/clientsources/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/clientsources/BUILD
@@ -9,6 +9,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "clientsources",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/info/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/info/BUILD
@@ -8,6 +8,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "info",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/mixin/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/mixin/BUILD
@@ -8,6 +8,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "mixin",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/proguardspecs/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/proguardspecs/BUILD
@@ -9,6 +9,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "proguardspecs",
     srcs = ["GenerateSdkProguardSpecsCommand.java"],

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/runtimeenabledsdkconfig/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/runtimeenabledsdkconfig/BUILD
@@ -8,6 +8,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "runtimeenabledsdkconfig",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/sdkdependenciesmanifest/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/sdkdependenciesmanifest/BUILD
@@ -8,6 +8,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "sdkdependenciesmanifest",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/sdksplitproperties/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/sdksplitproperties/BUILD
@@ -8,6 +8,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "sdksplitproperties",
     srcs = glob(["*.java"]),

--- a/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/validatemodulesconfig/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox/validatemodulesconfig/BUILD
@@ -9,6 +9,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "srcs",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/java/com/google/devtools/build/android/sandboxedsdktoolbox:__pkg__"],
+)
+
 java_library(
     name = "validatemodulesconfig",
     srcs = glob(["*.java"]),

--- a/src/tools/java_resource_extractor/BUILD
+++ b/src/tools/java_resource_extractor/BUILD
@@ -3,6 +3,12 @@
 
 load("@rules_python//python:defs.bzl", "py_binary")
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 py_binary(
     name = "resource_extractor",
     srcs = ["resource_extractor.py"],

--- a/src/tools/jdeps/BUILD
+++ b/src/tools/jdeps/BUILD
@@ -11,6 +11,14 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]) + [
+        "//src/tools/jdeps/proto:all_files",
+    ],
+    visibility = ["//:__pkg__"]
+)
+
 go_binary(
     name = "jdeps",
     srcs = ["jdeps.go"],

--- a/src/tools/jdeps/proto/BUILD
+++ b/src/tools/jdeps/proto/BUILD
@@ -1,6 +1,12 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src/tools/jdeps:__pkg__"],
+)
+
 go_proto_library(
     name = "deps_go_proto",
     importpath = "src/tools/jdeps/proto/deps_go_proto",

--- a/src/tools/mi/deployment_oss/BUILD
+++ b/src/tools/mi/deployment_oss/BUILD
@@ -6,6 +6,12 @@ package(
     default_visibility = ["//src/tools/mi/deployment_oss:__pkg__"],
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 go_binary(
     name = "deploy_binary",
     srcs = ["deploy_binary.go"],

--- a/src/tools/split_core_jar/BUILD
+++ b/src/tools/split_core_jar/BUILD
@@ -1,5 +1,11 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 go_binary(
     name = "split_core_jar",
     embed = [":split_core_jar_lib"],

--- a/src/validations/aar_import_checks/BUILD
+++ b/src/validations/aar_import_checks/BUILD
@@ -4,6 +4,12 @@ package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"]
+)
+
 genrule(
     name = "gen_aar_import_checks_sh",
     outs = ["aar_import_checks.sh"],

--- a/src/validations/validate_manifest/BUILD
+++ b/src/validations/validate_manifest/BUILD
@@ -12,6 +12,12 @@ package(
 
 licenses(["notice"])
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"]
+)
+
 py_library(
     name = "validate_manifest_lib",
     srcs = ["validate_manifest.py"],

--- a/stardoc/BUILD
+++ b/stardoc/BUILD
@@ -8,6 +8,12 @@ bzl_library(
     deps = ["//rules:bzl"],
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//src:__pkg__"]
+)
+
 # Run with `--workspace_status_command='echo STABLE_GIT_COMMIT $(git rev-parse HEAD)'`
 # to get the git commit stamping in the header.
 stardoc(

--- a/toolchains/android/BUILD
+++ b/toolchains/android/BUILD
@@ -10,6 +10,7 @@ licenses(["notice"])
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
 )
 
 # Android Toolchain Type

--- a/toolchains/android_sdk/BUILD
+++ b/toolchains/android_sdk/BUILD
@@ -8,6 +8,7 @@ licenses(["notice"])
 filegroup(
     name = "all_files",
     srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
 )
 
 # Android SDK Toolchain Type

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -9,6 +9,13 @@ package(
     default_visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]) + [
+        "//tools/android/xslt:all_files"
+    ],
+)
+
 config_setting(
     name = "minimal_desugaring",
     values = {

--- a/tools/android/xslt/BUILD
+++ b/tools/android/xslt/BUILD
@@ -7,3 +7,9 @@ sh_binary(
     srcs = ["xslt.sh"],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//tools/android:__pkg__"],
+)

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -124,4 +124,10 @@ alias(
     visibility = ["//visibility:public"],
 )
 
+filegroup(
+    name = "all_files",
+    srcs = glob(["**"]),
+    visibility = ["//:__pkg__"],
+)
+
 exports_files(["java_stub_template.txt"])


### PR DESCRIPTION
This will enable setting up a mock/fungible rules_android environment so that we can do end-to-end testing from within `bazel test`, after integrating with rules_bazel_integration_test.