### PR TITLE
Fix NoClassDefFoundError for ZipWritter

### DIFF
--- a/src/tools/java/com/google/devtools/build/android/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/BUILD
@@ -31,6 +31,7 @@ run_singlejar(
     out = "singlejar.jar",
     include_prefixes = [
         "com/google/devtools/build/singlejar/",
+        "com/google/devtools/build/zip/",
     ],
 )
 


### PR DESCRIPTION
**Background**
Rebase to latest commit of rules_android led to this issue 
```
Exception in thread "main" java.lang.NoClassDefFoundError: com/google/devtools/build/zip/ZipWriter
        at com.google.devtools.build.android.ZipFilterAction.run(ZipFilterAction.java:263)
        at com.google.devtools.build.android.ZipFilterAction.main(ZipFilterAction.java:220)
Caused by: java.lang.ClassNotFoundException: com.google.devtools.build.zip.ZipWriter
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:520)
        ... 2 more
```

Most likely a regression from https://github.com/bazelbuild/rules_android/commit/941f124e8d13c45701e32b33e9cea14496bef548

**Change**
Include the missing zip path into include_prefixes list