### PR TITLE
Use `ctx.getenv` to establish dependency on SDK home envvar

### DIFF
--- a/rules/android_sdk_repository/rule.bzl
+++ b/rules/android_sdk_repository/rule.bzl
@@ -94,7 +94,7 @@ def _android_sdk_repository_impl(repo_ctx):
     # Determine the SDK path to use, either from the attribute or the environment.
     android_sdk_path = repo_ctx.attr.path
     if not android_sdk_path:
-        android_sdk_path = repo_ctx.os.environ.get("ANDROID_HOME")
+        android_sdk_path = repo_ctx.getenv("ANDROID_HOME")
     if not android_sdk_path:
         # Create an empty repository that allows non-Android code to build.
         repo_ctx.template("BUILD.bazel", _EMPTY_SDK_REPO_TEMPLATE)


### PR DESCRIPTION
Per https://bazel.build/rules/lib/builtins/repository_os.html#environ:

> NOTE: Retrieving an environment variable from this dictionary does not establish a dependency from a repository rule or module extension to the environment variable. To establish a dependency when looking up an environment variable, use either repository_ctx.getenv or module_ctx.getenv instead.

Analogous to bazelbuild/rules_android_ndk#102