### PR TITLE
Exclude instrumented class files in resource extraction

### DIFF
--- a/src/tools/java_resource_extractor/resource_extractor.py
+++ b/src/tools/java_resource_extractor/resource_extractor.py
@@ -39,6 +39,7 @@ EXCLUDED_EXTENSIONS = (
     '.java',  # Java source files
     '.scala',  # Scala source files
     '.class',  # Java class files
+    '.class.uninstrumented',  # Uninstrumented Java class files
     '.scc',  # Visual SourceSafe
     '.swp',  # vi swap file
     '.gwt.xml',  # Google Web Toolkit modules


### PR DESCRIPTION
I noticed that `.class.instrumented` files ended up in the final unsigned APK as a result of the resource extractor not excluding these instrumented class files.