### PR TITLE
Fix generated Android manifest package name

### DIFF
--- a/rules/resources.bzl
+++ b/rules/resources.bzl
@@ -1386,7 +1386,7 @@ def _process_starlark(
             _generate_dummy_manifest(
                 ctx,
                 out_manifest = generated_manifest,
-                java_package = java_package if java_package else ctx.label.package.replace("/", "."),
+                java_package = java_package if java_package else ctx.label.package.replace("/", ".").replace("-", "."),
                 min_sdk_version = _min_sdk_version.DEPOT_FLOOR,
             )
             r_txt = ctx.actions.declare_file(ctx.label.name + "_symbols/R.txt")


### PR DESCRIPTION
Fix invalid Android package name generation when the Bazel package contains hyphens.
Hyphens (-) are not valid in Java package names, so we now replace them with dots (.) when generating the dummy manifest to prevent build errors and invalid manifests.

https://github.com/bazelbuild/rules_android/issues/445