### PR TITLE
Fix R8 processor to read minSdkVersion from manifest_values

### DIFF
--- a/rules/android_binary/r8.bzl
+++ b/rules/android_binary/r8.bzl
@@ -18,6 +18,7 @@ load("//rules:acls.bzl", "acls")
 load("//rules:android_neverlink_aspect.bzl", "StarlarkAndroidNeverlinkInfo")
 load("//rules:common.bzl", "common")
 load("//rules:java.bzl", "java")
+load("//rules:min_sdk_version.bzl", "min_sdk_version")
 load(
     "//rules:processing_pipeline.bzl",
     "ProviderInfo",
@@ -35,7 +36,7 @@ load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
 
 visibility(PROJECT_VISIBILITY)
 
-def process_r8(ctx, validation_ctx, jvm_ctx, packaged_resources_ctx, build_info_ctx, manifest_ctx, **_unused_ctxs):
+def process_r8(ctx, validation_ctx, jvm_ctx, packaged_resources_ctx, build_info_ctx, **_unused_ctxs):
     """Runs R8 for desugaring, optimization, and dexing.
 
     Args:
@@ -44,7 +45,6 @@ def process_r8(ctx, validation_ctx, jvm_ctx, packaged_resources_ctx, build_info_
       jvm_ctx: Context from the java processor.
       packaged_resources_ctx: Context from resource processing.
       build_info_ctx: Context from build info processor.
-      manifest_ctx: Context from manifest processing (provides min SDK version).
       **_unused_ctxs: Unused context.
 
     Returns:
@@ -82,21 +82,23 @@ def process_r8(ctx, validation_ctx, jvm_ctx, packaged_resources_ctx, build_info_
     android_jar = get_android_sdk(ctx).android_jar
     proguard_specs = proguard.get_proguard_specs(ctx, packaged_resources_ctx.resource_proguard_config)
 
-    # Get min SDK version from manifest context (populated from attribute or manifest_values)
-    min_sdk_version = manifest_ctx.processed_min_sdk_version
-
-    # For native multidex, min SDK must be at least 21 (Android 5.0+)
-    if ctx.attr.multidex == "native" and min_sdk_version < 21:
-        fail("Native multidex requires minSdkVersion >= 21, but got %s. " % min_sdk_version +
-             "Either set minSdkVersion to 21 or higher, or use multidex = 'legacy'.")
+    # Get min SDK version from attribute, manifest_values, or depot floor
+    effective_min_sdk = min_sdk_version.DEPOT_FLOOR
+    min_sdk_attr = getattr(ctx.attr, "min_sdk_version", 0)
+    if min_sdk_attr:
+        effective_min_sdk = max(effective_min_sdk, min_sdk_attr)
+    manifest_values = getattr(ctx.attr, "manifest_values", {})
+    if "minSdkVersion" in manifest_values:
+        manifest_min_sdk_str = manifest_values["minSdkVersion"]
+        if manifest_min_sdk_str.isdigit():
+            effective_min_sdk = max(effective_min_sdk, int(manifest_min_sdk_str))
 
     neverlink_infos = utils.collect_providers(StarlarkAndroidNeverlinkInfo, ctx.attr.deps)
     neverlink_jars = depset(transitive = [info.transitive_neverlink_libraries for info in neverlink_infos])
 
     args = ctx.actions.args()
     args.add("--release")
-    if min_sdk_version:
-        args.add("--min-api", min_sdk_version)
+    args.add("--min-api", effective_min_sdk)
     args.add("--output", dexes_zip)
     args.add_all(proguard_specs, before_each = "--pg-conf")
     args.add("--lib", android_jar)

--- a/rules/resources.bzl
+++ b/rules/resources.bzl
@@ -1056,21 +1056,10 @@ def _bump_min_sdk(
             floor,
         )
 
-    # Determine processed_min_sdk_version from multiple sources, taking the max:
-    # 1. min_sdk_version attribute (if set)
-    # 2. manifest_values["minSdkVersion"] (if present and numeric)
-    # 3. floor value
-    effective_min_sdk = floor if floor else 0
-
     if min_sdk_version != 0:
-        effective_min_sdk = max(effective_min_sdk, min_sdk_version)
-
-    if manifest_values and _MIN_SDK_VERSION in manifest_values:
-        manifest_min_sdk_str = manifest_values[_MIN_SDK_VERSION]
-        if manifest_min_sdk_str.isdigit():
-            effective_min_sdk = max(effective_min_sdk, int(manifest_min_sdk_str))
-
-    manifest_ctx[_PROCESSED_MIN_SDK_VERSION] = effective_min_sdk
+        manifest_ctx[_PROCESSED_MIN_SDK_VERSION] = max(min_sdk_version, floor)
+    else:
+        manifest_ctx[_PROCESSED_MIN_SDK_VERSION] = 0
 
     if not manifest or floor <= 0:
         manifest_ctx[_PROCESSED_MANIFEST] = manifest


### PR DESCRIPTION
When calculating the minSdkVersion we need take into account ALL the possible ways that value can be passed.

So the idea here is to take max value from `floor`, `min_sdk_version` attribute and `manifest_values["minSdkVersion"]`.