### PR TITLE
Export platform-tools/adb for incompatible_no_implicit_file_export

### DIFF
--- a/rules/android_sdk_repository/template.bzl
+++ b/rules/android_sdk_repository/template.bzl
@@ -80,6 +80,8 @@ create_android_sdk_rules(
     default_api_level = __default_api_level__,
 )
 
+exports_files(["platform-tools/adb"])
+
 alias(
     name = "adb",
     actual = "platform-tools/adb",


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_android/issues/440
Fixes #468

Adding exports_files to make https://github.com/bazelbuild/rules_android/blob/2985c25a21095df2ec0dc4377938d61dd532bcf6/rules/android_sdk_repository/template.bzl#L85 visible. Alternatively, we could use the alias in https://github.com/bazelbuild/rules_android/blob/2985c25a21095df2ec0dc4377938d61dd532bcf6/toolchains/android/toolchain.bzl#L55 instead of the file.