### PR TITLE
Set exports_manifest to True by default, to match documentation

### DIFF
--- a/rules/android_library/attrs.bzl
+++ b/rules/android_library/attrs.bzl
@@ -95,7 +95,7 @@ ATTRS = _attrs.add(
             ),
         ),
         exports_manifest = _attrs.tristate.create(
-            default = _attrs.tristate.no,
+            default = _attrs.tristate.yes,
             doc = (
                 "Whether to export manifest entries to `android_binary` targets that " +
                 "depend on this target. `uses-permissions` attributes are never exported."


### PR DESCRIPTION
According to Bazel [documentation](https://bazel.build/versions/6.2.0/reference/be/android#android_library.exports_manifest) the value of this flag is true by default (in native Android rules). Meanwhile, Starlark rules_android seems to be defaulting to False.

This PR aligns the behavior between native and Starlark rules.