### PR TITLE
Extract baseline-prof.txt from AARs in aar_import

### DIFF
--- a/rules/aar_import/impl.bzl
+++ b/rules/aar_import/impl.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Implementation."""
 
-load("//providers:providers.bzl", "AndroidLintRulesInfo", "AndroidNativeLibsInfo")
+load("//providers:providers.bzl", "AndroidLintRulesInfo", "AndroidNativeLibsInfo", "BaselineProfileProvider")
 load(
     "//rules:acls.bzl",
     _acls = "acls",
@@ -574,6 +574,18 @@ def impl(ctx):
         unzip_tool = unzip_tool,
     )
     providers.extend(lint_providers)
+
+    # Extract baseline-prof.txt from the AAR if present, otherwise create an empty file.
+    baseline_prof = create_aar_artifact(ctx, "baseline-prof.txt")
+    extract_single_file(
+        ctx,
+        baseline_prof,
+        aar,
+        "baseline-prof.txt",
+        unzip_tool,
+        create_empty_file = True,
+    )
+    providers.append(BaselineProfileProvider(files = depset([baseline_prof])))
 
     validation_outputs.append(_validate_rule(
         ctx,

--- a/rules/aar_import/rule.bzl
+++ b/rules/aar_import/rule.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """aar_import rule."""
 
-load("//providers:providers.bzl", "AndroidIdeInfo", "AndroidLibraryResourceClassJarProvider", "AndroidNativeLibsInfo")
+load("//providers:providers.bzl", "AndroidIdeInfo", "AndroidLibraryResourceClassJarProvider", "AndroidNativeLibsInfo", "BaselineProfileProvider")
 load(
     "//rules:utils.bzl",
     "ANDROID_SDK_TOOLCHAIN_TYPE",
@@ -60,6 +60,7 @@ aar_import = rule(
         AndroidIdeInfo,
         AndroidLibraryResourceClassJarProvider,
         AndroidNativeLibsInfo,
+        BaselineProfileProvider,
         JavaInfo,
     ],
     toolchains = [


### PR DESCRIPTION
aar_import now extracts baseline-prof.txt and provides BaselineProfileProvider, so baseline profiles from maven AARs propagate through the dependency graph to android_binary. Fixes: https://github.com/bazelbuild/rules_android/issues/461