### PR TITLE
Return ProguardMappingInfo after running R8

### DIFF
--- a/rules/android_binary/r8.bzl
+++ b/rules/android_binary/r8.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 """R8 processor steps for android_binary."""
 
-load("//providers:providers.bzl", "AndroidDexInfo", "AndroidPreDexJarInfo")
+load("//providers:providers.bzl", "AndroidDexInfo", "AndroidPreDexJarInfo", "ProguardMappingInfo")
 load("//rules:acls.bzl", "acls")
 load("//rules:android_neverlink_aspect.bzl", "StarlarkAndroidNeverlinkInfo")
 load("//rules:common.bzl", "common")
@@ -136,6 +136,7 @@ def process_r8(ctx, validation_ctx, jvm_ctx, packaged_resources_ctx, build_info_
             providers = [
                 android_dex_info,
                 AndroidPreDexJarInfo(pre_dex_jar = deploy_jar),
+                ProguardMappingInfo(proguard_mapping = proguard_mappings_output_file),
             ],
         ),
     )


### PR DESCRIPTION
Building optimized app bundle doesn't package proguard.map into the aab. We seem to be mising to return a provider, which gets checked here:
https://github.com/bazelbuild/rules_android/blob/main/rules/android_application/android_application_rule.bzl#L360C8-L361

Before:
<img width="669" height="364" alt="before" src="https://github.com/user-attachments/assets/04673ff5-c2b5-43a0-b2c4-d0ae6e85445c" />

After:
<img width="668" height="276" alt="after" src="https://github.com/user-attachments/assets/401b10d3-2739-4ac9-9c5e-0fdd9e4365c9" />