### PR TITLE
Fix non-deterministic properties.jar causing (remote) cache misses fo…

### DIFF
--- a/rules/android_local_test/impl.bzl
+++ b/rules/android_local_test/impl.bzl
@@ -522,7 +522,7 @@ tmp_dir=$(mktemp -d)
 
 cd $tmp_dir
 mkdir -p {dir_name}
-cp $base/{f} {dir_name}
+cp -p $base/{f} {dir_name}
 $base/{zip_tool} -jt -X -q $base/{out_zip} {dir_name}/$(basename {f})
 """.format(
         zip_tool = get_android_toolchain(ctx).zip_tool.files_to_run.executable.path,


### PR DESCRIPTION
…r Robolectric tests

Robolectric tests in android_local_test rules produce a properties.jar archive containing test_config.properties. This jar is an input to the TestRunner action, so its SHA-256 hash is part of the remote cache key.

On CI, TestRunner consistently missed the remote cache even when nothing had changed.

In rules/android_local_test/impl.bzl, the _zip_file helper stages the file before zipping:

```
  cp $base/{f} {dir_name}
  zip -jt -X -q $base/{out_zip} {dir_name}/$(basename {f})
```

Because cp is used without -p, it resets the file's mtime to the current time. The zip tool embeds this timestamp into the archive. Note that zip -X does not reset mtime (which is the problem here).

As a result, two CI agents produce properties.jar files with identical content but different timestamps → different SHA-256 → cache miss.

Use `cp -p` to preserve the original mtime of file, which is deterministic (because file is created by starlark ctx.actions.expand_template method)

This makes the zip output deterministic across agents and stabilizes the TestRunner cache key.