### PR TITLE
Use abi name when producing android binary

### DIFF
--- a/rules/aar_import/attrs.bzl
+++ b/rules/aar_import/attrs.bzl
@@ -73,21 +73,8 @@ ATTRS = _attrs.add(
         _manifest_merge_order = attr.label(
             default = "//rules/flags:manifest_merge_order",
         ),
-        _cpu_constraints = attr.label_keyed_string_dict(
-            default = {
-                # The keys are labels to constraint_value targets representing the CPU for Android
-                # devices, and the key is the corresponding directory name for that CPU in the
-                # jni/ directory of an AAR. This is used to find the correct directory under jni/
-                # from the platform(s) specified with --android_platforms. See
-                # https://developer.android.com/studio/projects/android-library#aar-contents
-                "@platforms//cpu:arm64": "arm64-v8a",
-                "@platforms//cpu:armv7": "armeabi-v7a",
-                "@platforms//cpu:x86_32": "x86",
-                "@platforms//cpu:x86_64": "x86_64",
-                "@platforms//cpu:riscv64": "riscv64",
-            },
-        ),
     ),
+    _attrs.CPU_CONSTRAINTS,
     _attrs.DATA_CONTEXT,
     _attrs.ANDROID_TOOLCHAIN_ATTRS,
     _attrs.AUTOMATIC_EXEC_GROUPS_ENABLED,

--- a/rules/aar_import/impl.bzl
+++ b/rules/aar_import/impl.bzl
@@ -38,6 +38,7 @@ load(
     _get_android_toolchain = "get_android_toolchain",
     _utils = "utils",
 )
+load("//rules:attrs.bzl", _attrs = "attrs")
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
 load("//rules/flags:flags.bzl", _flags = "flags")
 load("@rules_java//java/common:java_common.bzl", "java_common")
@@ -527,19 +528,7 @@ def impl(ctx):
     providers.extend(jvm_ctx.providers)
     validation_outputs.extend(jvm_ctx.validation_results)
 
-    native_libs_cpu = None
-    for target, cpu in ctx.attr._cpu_constraints.items():
-        constraint = target[platform_common.ConstraintValueInfo]
-        if ctx.target_platform_has_constraint(constraint):
-            native_libs_cpu = cpu
-            break
-    if native_libs_cpu == None:
-        fail(("Target platform %s does not match one of the " +
-              "applicable CPU constraints for aar_import %s. " +
-              "Applicable CPU constraints are listed in " +
-              "https://blog.bazel.build/2023/11/15/android-platforms.html") %
-             (ctx.fragments.platform.platform, ctx.label))
-
+    native_libs_cpu = _attrs.get_abi_name(ctx, ctx.attr._cpu_constraints)
     native_libs = create_aar_artifact(ctx, "native_libs.zip")
     _extract_native_libs(
         ctx,

--- a/rules/android_binary/attrs.bzl
+++ b/rules/android_binary/attrs.bzl
@@ -252,6 +252,7 @@ ATTRS = _attrs.replace(
             ),
         ),
         _attrs.compilation_attributes(apply_android_transition = True),
+        _attrs.CPU_CONSTRAINTS,
         _attrs.DATA_CONTEXT,
         _attrs.ANDROID_TOOLCHAIN_ATTRS,
         _attrs.AUTOMATIC_EXEC_GROUPS_ENABLED,

--- a/rules/android_binary/impl.bzl
+++ b/rules/android_binary/impl.bzl
@@ -155,6 +155,7 @@ def _process_native_libs(ctx, **_unused_ctxs):
     native_libs_info = _process_native_deps(
         ctx,
         filename = "nativedeps",
+        cpu_constraints = ctx.attr._cpu_constraints,
     )
     providers.append(native_libs_info)
     return ProviderInfo(

--- a/rules/attrs.bzl
+++ b/rules/attrs.bzl
@@ -508,10 +508,48 @@ _AUTOMATIC_EXEC_GROUPS_ENABLED = dict(
     _use_auto_exec_groups = attr.bool(default = True),
 )
 
+# Mapping of CPU constraint_value targets to Android ABI directory names.
+# See https://developer.android.com/ndk/guides/abis
+_CPU_CONSTRAINTS = dict(
+    _cpu_constraints = attr.label_keyed_string_dict(
+        default = {
+            "@platforms//cpu:arm64": "arm64-v8a",
+            "@platforms//cpu:armv7": "armeabi-v7a",
+            "@platforms//cpu:x86_32": "x86",
+            "@platforms//cpu:x86_64": "x86_64",
+            "@platforms//cpu:riscv64": "riscv64",
+        },
+    ),
+)
+
+def _get_abi_name(ctx, cpu_constraints):
+    """Returns the Android ABI name for the current target platform.
+
+    Args:
+        ctx: The rule context.
+        cpu_constraints: A label_keyed_string_dict mapping constraint_value
+            targets to ABI name strings (e.g. {"@platforms//cpu:arm64": "arm64-v8a"}).
+
+    Returns:
+        The ABI name string, or None if no constraint matches.
+    """
+    for target, abi in cpu_constraints.items():
+        constraint = target[platform_common.ConstraintValueInfo]
+        if ctx.target_platform_has_constraint(constraint):
+            return abi
+
+    fail(("Target platform %s does not match one of the " +
+          "applicable CPU constraints for aar_import %s. " +
+          "Applicable CPU constraints are listed in " +
+          "https://blog.bazel.build/2023/11/15/android-platforms.html") %
+         (ctx.fragments.platform.platform, ctx.label))
+
 attrs = struct(
     ANDROID_SDK = _ANDROID_SDK,
     compilation_attributes = _compilation_attributes,
+    CPU_CONSTRAINTS = _CPU_CONSTRAINTS,
     DATA_CONTEXT = _DATA_CONTEXT,
+    get_abi_name = _get_abi_name,
     JAVA_RUNTIME = _JAVA_RUNTIME,
     ANDROID_TOOLCHAIN_ATTRS = _ANDROID_TOOLCHAIN_ATTRS,
     tristate = _tristate,

--- a/rules/native_deps.bzl
+++ b/rules/native_deps.bzl
@@ -17,6 +17,7 @@ of split deps
 """
 
 load("//providers:providers.bzl", "AndroidBinaryNativeLibsInfo", "AndroidCcLinkParamsInfo", "AndroidNativeLibsInfo")
+load("//rules:attrs.bzl", _attrs = "attrs")
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
 load("@rules_cc//cc/common:cc_common.bzl", "cc_common")
 load("@rules_cc//cc/common:cc_info.bzl", "CcInfo")
@@ -45,10 +46,6 @@ split_config_aspect = aspect(
     fragments = ["android"],
 )
 
-def _get_libs_dir_name(target_platform):
-    name = target_platform.name
-    return name
-
 def _get_cc_link_params_infos(ctx, deps):
     infos = []
     for dep in deps:
@@ -73,7 +70,7 @@ def _get_cc_link_params_infos(ctx, deps):
 
     return infos
 
-def process(ctx, filename, merged_libraries_map = {}):
+def process(ctx, filename, merged_libraries_map = {}, cpu_constraints = {}):
     """Links native deps into a shared library
 
     Args:
@@ -97,14 +94,13 @@ def process(ctx, filename, merged_libraries_map = {}):
     target_name = ctx.label.name
     native_libs_basename = None
     libs_name = None
+    abi_name = _attrs.get_abi_name(ctx, cpu_constraints) if cpu_constraints else None
     libs = dict()
     for key, deps in ctx.split_attr.deps.items():
         cc_toolchain_dep = ctx.split_attr._cc_toolchain_split[key]
         cc_toolchain = cc_toolchain_dep[cc_common.CcToolchainInfo]
         build_config = cc_toolchain_dep[SplitConfigInfo].build_config
-        libs_dir_name = _get_libs_dir_name(
-            cc_toolchain_dep[SplitConfigInfo].target_platform,
-        )
+        libs_dir_name = abi_name
         linker_input = cc_common.create_linker_input(
             owner = ctx.label,
             user_link_flags = ["-Wl,-soname=lib" + target_name],


### PR DESCRIPTION
Reuse the aar_import's way of handling abi_name by refactoring out the cpu_constraints to attrs.bzl and update the process() function, which previously use _get_libs_dir_name for creating directory name.

Should fix #365