### PR TITLE
Get core-for-system-modules.jar via AndroidSdkInfo.

### DIFF
--- a/providers/providers.bzl
+++ b/providers/providers.bzl
@@ -440,7 +440,8 @@ def _AndroidSdkInfo_init(
         proguard,
         zip_align,
         system,  # not used
-        legacy_main_dex_list_generator):
+        legacy_main_dex_list_generator,
+        core_for_system_modules_jar = None):
     return {
         "android_jar": android_jar,
         "legacy_main_dex_list_generator": legacy_main_dex_list_generator,
@@ -460,6 +461,7 @@ def _AndroidSdkInfo_init(
         "aidl_lib": aidl_lib,
         "framework_aidl": framework_aidl,
         "build_tools_version": build_tools_version,
+        "core_for_system_modules_jar": core_for_system_modules_jar,
     }
 
 # buildifier: disable=name-conventions
@@ -485,6 +487,7 @@ AndroidSdkInfo, _AndroidSdkInfo_raw = provider(
         proguard = "",
         legacy_main_dex_list_generator = "",
         zip_align = "",
+        core_for_system_modules_jar = "",
     ),
 )
 

--- a/rules/android_sdk.bzl
+++ b/rules/android_sdk.bzl
@@ -41,6 +41,7 @@ def _impl(ctx):
         zip_align = ctx.attr.zipalign.files_to_run,
         system = None,
         legacy_main_dex_list_generator = ctx.attr.legacy_main_dex_list_generator.files_to_run if ctx.attr.legacy_main_dex_list_generator else None,
+        core_for_system_modules_jar = ctx.file.core_for_system_modules_jar if ctx.attr.core_for_system_modules_jar else None,
     )
     return [
         android_sdk_info,

--- a/rules/android_sdk_repository/helper.bzl
+++ b/rules/android_sdk_repository/helper.bzl
@@ -240,6 +240,7 @@ def create_android_sdk_rules(
                 ":windows": "build-tools/%s/zipalign.exe" % build_tools_directory,
                 "//conditions:default": ":zipalign_binary",
             }),
+            core_for_system_modules_jar = "platforms/android-%d/core-for-system-modules.jar" % api_level,
         )
 
         native.toolchain(

--- a/rules/attrs.bzl
+++ b/rules/attrs.bzl
@@ -495,6 +495,9 @@ ANDROID_SDK_ATTRS = dict(
         executable = True,
         mandatory = True,
     ),
+    core_for_system_modules_jar = attr.label(
+        allow_single_file = [".jar"],
+    ),
     _proguard = attr.label(
         cfg = "exec",
         default = configuration_field(

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -2,7 +2,7 @@ load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library",
 load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//rules:min_sdk_version.bzl", "min_sdk_version")
-load(":defs.bzl", "android_jar", "run_ijar", "run_singlejar")
+load(":defs.bzl", "android_jar", "core_for_system_modules_jar", "run_ijar", "run_singlejar")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -25,6 +25,11 @@ config_setting(
 
 android_jar(
     name = "android_jar",
+    visibility = ["//visibility:public"],
+)
+
+core_for_system_modules_jar(
+    name = "core_for_system_modules_jar",
     visibility = ["//visibility:public"],
 )
 

--- a/tools/android/defs.bzl
+++ b/tools/android/defs.bzl
@@ -33,6 +33,19 @@ android_jar = rule(
     ],
 )
 
+def _core_for_system_modules_jar_impl(ctx):
+    sdk = get_android_sdk(ctx)
+    if sdk.core_for_system_modules_jar:
+        return DefaultInfo(files = depset([sdk.core_for_system_modules_jar]))
+    return DefaultInfo(files = depset())
+
+core_for_system_modules_jar = rule(
+    implementation = _core_for_system_modules_jar_impl,
+    toolchains = [
+        ANDROID_SDK_TOOLCHAIN_TYPE,
+    ],
+)
+
 def _run_singlejar_impl(ctx):
     _java.singlejar(
         ctx,

--- a/tools/jdk/BUILD
+++ b/tools/jdk/BUILD
@@ -78,7 +78,7 @@ android_system(
         "//tools/android:desugar_java8_extra_bootclasspath",
     ],
     core_jars = [
-        "@androidsdk//:core-for-system-modules-jar",
+        "//tools/android:core_for_system_modules_jar",
     ],
 )
 


### PR DESCRIPTION
tools/jdk/BUILD previously hardcoded @androidsdk//:core-for-system-modules-jar, which assumes a local SDK is always present. Add core_for_system_modules_jar to AndroidSdkInfo and expose it via a toolchain-aware rule so that any SDK toolchain implementation (local or remote) can provide the jar. 