### PR TITLE
Correctly reference binaries on Windows

### DIFF
--- a/rules/android_sdk_repository/helper.bzl
+++ b/rules/android_sdk_repository/helper.bzl
@@ -209,10 +209,7 @@ def create_android_sdk_rules(
                 ":windows": "build-tools/%s/aapt.exe" % build_tools_directory,
                 "//conditions:default": ":aapt_binary",
             }),
-            aapt2 = select({
-                ":windows": "build-tools/%s/aapt2.exe" % build_tools_directory,
-                "//conditions:default": ":aapt2_binary",
-            }),
+            aapt2 = ":aapt2",
             adb = select({
                 ":windows": "platform-tools/adb.exe",
                 "//conditions:default": "platform-tools/adb",
@@ -239,10 +236,7 @@ def create_android_sdk_rules(
             }),
             # See https://github.com/bazelbuild/bazel/issues/8757
             tags = ["__ANDROID_RULES_MIGRATION__"],
-            zipalign = select({
-                ":windows": "build-tools/%s/zipalign.exe" % build_tools_directory,
-                "//conditions:default": ":zipalign_binary",
-            }),
+            zipalign = ":zipalign",
         )
 
         native.toolchain(
@@ -353,6 +347,14 @@ def create_android_sdk_rules(
         actual = select({
             ":windows": "build-tools/%s/aapt2.exe" % build_tools_directory,
             "//conditions:default": ":aapt2_binary",
+        }),
+    )
+
+    native.alias(
+        name = "zipalign",
+        actual = select({
+            ":windows": "build-tools/%s/zipalign.exe" % build_tools_directory,
+            "//conditions:default": ":zipalign_binary",
         }),
     )
 

--- a/rules/java.bzl
+++ b/rules/java.bzl
@@ -464,7 +464,7 @@ def _run(
 
     # Set reasonable max heap default. Required to prevent runaway memory usage.
     # Can still be overridden by callers of this method.
-    jvm_flags = ["-Xms512M", "-Xmx3G", "-XX:+ExitOnOutOfMemoryError"] + jvm_flags
+    jvm_flags = ["-Xmx3G", "-Xmx3G", "-XX:+ExitOnOutOfMemoryError"] + jvm_flags
 
     # executable should be a File or a FilesToRunProvider
     jar = args.get("executable")

--- a/rules/java.bzl
+++ b/rules/java.bzl
@@ -464,7 +464,7 @@ def _run(
 
     # Set reasonable max heap default. Required to prevent runaway memory usage.
     # Can still be overridden by callers of this method.
-    jvm_flags = ["-Xms3G", "-Xmx3G", "-XX:+ExitOnOutOfMemoryError"] + jvm_flags
+    jvm_flags = ["-Xms512M", "-Xmx3G", "-XX:+ExitOnOutOfMemoryError"] + jvm_flags
 
     # executable should be a File or a FilesToRunProvider
     jar = args.get("executable")

--- a/rules/java.bzl
+++ b/rules/java.bzl
@@ -464,7 +464,7 @@ def _run(
 
     # Set reasonable max heap default. Required to prevent runaway memory usage.
     # Can still be overridden by callers of this method.
-    jvm_flags = ["-Xmx3G", "-Xmx3G", "-XX:+ExitOnOutOfMemoryError"] + jvm_flags
+    jvm_flags = ["-Xms3G", "-Xmx3G", "-XX:+ExitOnOutOfMemoryError"] + jvm_flags
 
     # executable should be a File or a FilesToRunProvider
     jar = args.get("executable")


### PR DESCRIPTION
`bazel build` fails to find the right `zipalign` binary on Windows because the `select` in `android_sdk` is always falling back to the default branch. Apply the same fix that was applied to `aapt2` in https://github.com/bazelbuild/rules_android/pull/235