### PR TITLE
Allow tweaking jvm flags per mnemonic

### DIFF
--- a/rules/aar_import/attrs.bzl
+++ b/rules/aar_import/attrs.bzl
@@ -63,6 +63,10 @@ ATTRS = _attrs.add(
         _flags = attr.label(
             default = "//rules/flags",
         ),
+        _jvm_args = attr.label(
+            default = "//rules/flags:jvm_args",
+            doc = "Additional flags to pass to the JVM when invoking tools.",
+        ),
         _java_toolchain = attr.label(
             default = Label("//tools/jdk:toolchain_android_only"),
         ),

--- a/rules/aar_import/attrs.bzl
+++ b/rules/aar_import/attrs.bzl
@@ -63,12 +63,6 @@ ATTRS = _attrs.add(
         _flags = attr.label(
             default = "//rules/flags",
         ),
-        _mnemonic_jvm_flags = attr.label(
-            default = "//rules/flags:mnemonic_jvm_flags",
-            doc = "Additional JVM flags to set depending on the mnemonic " +
-                  "E.g --//rules/flags:mnemonic_jvm_flags=CompileAndroidResources=Xms1G " +
-                  " will add -Xms1G to all invocations of the CompileAndroidResources mnemonic",
-        ),
         _java_toolchain = attr.label(
             default = Label("//tools/jdk:toolchain_android_only"),
         ),
@@ -78,6 +72,12 @@ ATTRS = _attrs.add(
         ),
         _manifest_merge_order = attr.label(
             default = "//rules/flags:manifest_merge_order",
+        ),
+        _mnemonic_jvm_flags = attr.label(
+            default = "//rules/flags:mnemonic_jvm_flags",
+            doc = "Additional JVM flags to set depending on the mnemonic " +
+                  "E.g --//rules/flags:mnemonic_jvm_flags=CompileAndroidResources=Xms1G " +
+                  " will add -Xms1G to all invocations of the CompileAndroidResources mnemonic",
         ),
         _cpu_constraints = attr.label_keyed_string_dict(
             default = {

--- a/rules/aar_import/attrs.bzl
+++ b/rules/aar_import/attrs.bzl
@@ -63,9 +63,11 @@ ATTRS = _attrs.add(
         _flags = attr.label(
             default = "//rules/flags",
         ),
-        _jvm_args = attr.label(
-            default = "//rules/flags:jvm_args",
-            doc = "Additional flags to pass to the JVM when invoking tools.",
+        _mnemonic_jvm_flags = attr.label(
+            default = "//rules/flags:mnemonic_jvm_flags",
+            doc = "Additional JVM flags to set depending on the mnemonic " +
+                  "E.g --//rules/flags:mnemonic_jvm_flags=CompileAndroidResources=Xms1G " +
+                  " will add -Xms1G to all invocations of the CompileAndroidResources mnemonic",
         ),
         _java_toolchain = attr.label(
             default = Label("//tools/jdk:toolchain_android_only"),

--- a/rules/android_library/attrs.bzl
+++ b/rules/android_library/attrs.bzl
@@ -179,6 +179,12 @@ ATTRS = _attrs.add(
                 "Add these flags to the AIDL compiler command."
             ),
         ),
+        _mnemonic_jvm_flags = attr.label(
+            default = "//rules/flags:mnemonic_jvm_flags",
+            doc = "Additional JVM flags to set depending on the mnemonic " +
+                  "E.g --//rules/flags:mnemonic_jvm_flags=CompileAndroidResources=Xms1G " +
+                  " will add -Xms1G to all invocations of the CompileAndroidResources mnemonic",
+        ),
         neverlink = attr.bool(
             default = False,
             doc = (

--- a/rules/busybox.bzl
+++ b/rules/busybox.bzl
@@ -14,6 +14,7 @@
 """Bazel ResourcesBusyBox Commands."""
 
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":busybox_compat.bzl", "AAPT2_COMPAT_FLAGS")
 load(":java.bzl", _java = "java")
 
@@ -840,11 +841,20 @@ def _merge_compiled(
         jvm_flags = _C1_ONLY_FLAGS,
     )
 
-def _java_run(ctx, mnemonic = None, *args, **kwargs):
+def _java_run(ctx, mnemonic = None, jvm_flags = [], *args, **kwargs):
     enable_workers = ctx.fragments.android.persistent_busybox_tools
     multiplex_workers = ctx.fragments.android.persistent_multiplex_busybox_tools
 
-    _java.run(ctx, mnemonic = mnemonic, supports_workers = enable_workers, supports_multiplex_workers = multiplex_workers, *args, **kwargs)
+    extra_jvm_flags = ctx.attr._jvm_args[BuildSettingInfo].value
+    _java.run(
+        ctx,
+        mnemonic = mnemonic,
+        supports_workers = enable_workers,
+        supports_multiplex_workers = multiplex_workers,
+        jvm_flags = jvm_flags + extra_jvm_flags,
+        *args,
+        **kwargs
+    )
 
 def _escape_mv(s):
     """Escapes `:` and `,` in manifest values so they can be used as a busybox flag."""

--- a/rules/busybox.bzl
+++ b/rules/busybox.bzl
@@ -14,7 +14,6 @@
 """Bazel ResourcesBusyBox Commands."""
 
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(":busybox_compat.bzl", "AAPT2_COMPAT_FLAGS")
 load(":java.bzl", _java = "java")
 

--- a/rules/flags/BUILD
+++ b/rules/flags/BUILD
@@ -150,7 +150,7 @@ string_list_flag(
 )
 
 string_list_flag(
-    name = "jvm_args",
+    name = "mnemonic_jvm_flags",
     build_setting_default = [],
     visibility = ["//visibility:public"],
 )

--- a/rules/flags/BUILD
+++ b/rules/flags/BUILD
@@ -6,6 +6,7 @@ load("//rules/flags:additional_flags.bzl", "additional_flags")
 load("//rules/flags:configurations.bzl", "configurations")
 load("//rules/flags:flag_defs.bzl", "define_flags")
 load("//rules/flags:flags.bzl", "flags")
+load("//rules/flags:mnemonic_flags.bzl", "mnemonic_flag")
 
 licenses(["notice"])
 
@@ -150,12 +151,6 @@ string_list_flag(
 )
 
 string_list_flag(
-    name = "mnemonic_jvm_flags",
-    build_setting_default = [],
-    visibility = ["//visibility:public"],
-)
-
-string_list_flag(
     name = "dexopts_supported_in_dexsharder",
     build_setting_default = ["--minimal-main-dex"],
     scope = "universal",
@@ -212,6 +207,12 @@ int_flag(
     name = "incremental_dexing_after_proguard",
     build_setting_default = 50,
     scope = "universal",
+    visibility = ["//visibility:public"],
+)
+
+mnemonic_flag(
+    name = "mnemonic_jvm_flags",
+    build_setting_default = "",
     visibility = ["//visibility:public"],
 )
 

--- a/rules/flags/BUILD
+++ b/rules/flags/BUILD
@@ -150,6 +150,12 @@ string_list_flag(
 )
 
 string_list_flag(
+    name = "jvm_args",
+    build_setting_default = [],
+    visibility = ["//visibility:public"],
+)
+
+string_list_flag(
     name = "dexopts_supported_in_dexsharder",
     build_setting_default = ["--minimal-main-dex"],
     scope = "universal",

--- a/rules/flags/mnemonic_flags.bzl
+++ b/rules/flags/mnemonic_flags.bzl
@@ -1,6 +1,9 @@
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
-def extract_jvm_flags_for_mnemonic(ctx, mnemonic):
+def _mnemonic_flag_impl(ctx):
+    return [BuildSettingInfo(value = ctx.build_setting_value)]
+
+def extract_values_for_mnemonic(ctx, mnemonic):
     flag_values = []
     for value in ctx.attr._mnemonic_jvm_flags[BuildSettingInfo].value:
         key, jvm_flag = value.split("=", 1)
@@ -8,3 +11,8 @@ def extract_jvm_flags_for_mnemonic(ctx, mnemonic):
             continue
         flag_values.append(jvm_flag)
     return flag_values
+
+mnemonic_flag = rule(
+    implementation = _mnemonic_flag_impl,
+    build_setting = config.string(flag = True, allow_multiple = True)
+)

--- a/rules/flags/mnemonic_flags.bzl
+++ b/rules/flags/mnemonic_flags.bzl
@@ -1,0 +1,10 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+def extract_jvm_flags_for_mnemonic(ctx, mnemonic):
+    flag_values = []
+    for value in ctx.attr._mnemonic_jvm_flags[BuildSettingInfo].value:
+        key, jvm_flag = value.split("=", 1)
+        if key != mnemonic:
+            continue
+        flag_values.append(jvm_flag)
+    return flag_values

--- a/rules/java.bzl
+++ b/rules/java.bzl
@@ -14,6 +14,7 @@
 """Bazel Java APIs for the Android rules."""
 
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
+load("//rules/flags:mnemonic_flags.bzl", "extract_jvm_flags_for_mnemonic")
 load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//java/private:android_support.bzl", "android_support")  # buildifier: disable=bzl-visibility
 load(":path.bzl", _path = "path")
@@ -465,6 +466,11 @@ def _run(
     # Set reasonable max heap default. Required to prevent runaway memory usage.
     # Can still be overridden by callers of this method.
     jvm_flags = ["-Xms3G", "-Xmx3G", "-XX:+ExitOnOutOfMemoryError"] + jvm_flags
+
+    # Additional JVM flags depending on the mnemonic
+    if mnemonic and getattr(ctx.attr, "_mnemonic_jvm_flags", None):
+        extra_jvm_flags = extract_jvm_flags_for_mnemonic(ctx, mnemonic)
+        jvm_flags += extra_jvm_flags
 
     # executable should be a File or a FilesToRunProvider
     jar = args.get("executable")

--- a/rules/java.bzl
+++ b/rules/java.bzl
@@ -14,7 +14,7 @@
 """Bazel Java APIs for the Android rules."""
 
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
-load("//rules/flags:mnemonic_flags.bzl", "extract_jvm_flags_for_mnemonic")
+load("//rules/flags:mnemonic_flags.bzl", "extract_values_for_mnemonic")
 load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//java/private:android_support.bzl", "android_support")  # buildifier: disable=bzl-visibility
 load(":path.bzl", _path = "path")
@@ -469,8 +469,9 @@ def _run(
 
     # Additional JVM flags depending on the mnemonic
     if mnemonic and getattr(ctx.attr, "_mnemonic_jvm_flags", None):
-        extra_jvm_flags = extract_jvm_flags_for_mnemonic(ctx, mnemonic)
-        jvm_flags += extra_jvm_flags
+        extra_jvm_flags = extract_values_for_mnemonic(ctx, mnemonic)
+        if extra_jvm_flags:
+            jvm_flags += extra_jvm_flags
 
     # executable should be a File or a FilesToRunProvider
     jar = args.get("executable")


### PR DESCRIPTION
The default Xms value for the JVM tool calls is too large and can cause builds to fail on machines with restricted resources (e.g building a large Android application a single Windows machine).

This change introduces a flag that allows tweaking JVM settings per action.

Example usage:

 ```
bazel build //my:application --config=android \
  --@rules_android//rules:mnemonic_jvm_flags=CompileAndroidResources=-Xms512M \
  --@rules_android//rules:mnemonic_jvm_flags=StarlarkMergeCompiledAndroidResources=-Xms1G
```

Relates to https://github.com/bazelbuild/rules_android/issues/302
