### PR TITLE
Use `short_path` instead of  `path` to create filename

### DIFF
--- a/rules/dex_desugar_aspect.bzl
+++ b/rules/dex_desugar_aspect.bzl
@@ -124,7 +124,7 @@ def _aspect_impl(target, ctx):
         for jar in runtime_jars:
             if ctx.fragments.android.desugar_java8:
                 jar_to_desugar = jar
-                unique_desugar_filename = (jar.path if basename_clash else jar.basename) + "_desugared.jar"
+                unique_desugar_filename = (jar.short_path if basename_clash else jar.basename) + "_desugared.jar"
                 desugared_jar = _dex.get_dx_artifact(ctx, unique_desugar_filename, min_sdk_version)
 
                 # Optionally transform the jar before desugaring


### PR DESCRIPTION
Use `short_path` instead of  `path` to create filename

Using `path` contains platform specific components (e.g. `darwin-arm64-dbg`) which result in different cache key even when `path-mapping` is enabled. This fixes `path-mapping` support for desugar and dex actions