### PR TITLE
Update tests link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ the one above, the
    an [issue](https://github.com/bazelbuild/rules_android/issues) or comment on
    an existing issue.
 1. Prepare a git commit with your change. Don't forget to
-   add [tests](https://github.com/bazelbuild/rules_android/tree/master/tests).
+   add [tests](https://github.com/bazelbuild/rules_android/tree/main/test).
    Run the existing tests with `bazel test //...`. Update
    [README.md](https://github.com/bazelbuild/rules_android/blob/master/README.md)
    if appropriate.


### PR DESCRIPTION
Updated a link that pointed to an old `master` branch.