### PR TITLE
android toolchain: add the missing xmllint tool

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,6 +9,7 @@ bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_java", version = "9.3.0")
 bazel_dep(name = "rules_cc", version = "0.2.14")
 bazel_dep(name = "rules_shell", version = "0.6.1")
+bazel_dep(name = "libxml2", version = "2.15.3")
 
 bazel_dep(name = "stardoc", version = "0.8.0", dev_dependency = True)
 
@@ -59,6 +60,7 @@ python.toolchain(
 bazel_dep(name = "rules_proto", version = "7.1.0", repo_name = "rules_proto")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
+
 # Maven for android_ide_common need to be separated into their own separate maven_install for now
 # due to compatibility issues with newer versions.
 maven.install(

--- a/prereqs.bzl
+++ b/prereqs.bzl
@@ -212,6 +212,18 @@ def rules_android_prereqs(dev_mode = False):
         ],
     )
 
+    maybe(
+        http_archive,
+        name = "libxml2",
+        sha256 = "0da50c1415f4ec0364569d2119b1436ba837b31df44af28569d234272c23cf1f",
+        strip_prefix = "libxml2-v2.15.3",
+        build_file = Label("//third_party/libxml2:BUILD.bazel"),
+        patches = [Label("//third_party/libxml2:00_config_h.patch")],
+        urls = [
+            "https://gitlab.gnome.org/GNOME/libxml2/-/archive/v2.15.3/libxml2-v2.15.3.tar.gz",
+        ],
+    )
+
     _apksig_archive()
     _com_android_dex_archive()
 

--- a/toolchains/android/toolchain.bzl
+++ b/toolchains/android/toolchain.bzl
@@ -269,6 +269,12 @@ _ATTRS = dict(
         default = "//toolchains/android:unzip",
         executable = True,
     ),
+    xmllint_tool = attr.label(
+        cfg = "exec",
+        default = "@libxml2//:xmllint",
+        allow_files = True,
+        executable = True,
+    ),
     xsltproc_tool = attr.label(
         cfg = "exec",
         default = Label("//tools/android/xslt:xslt"),


### PR DESCRIPTION
It's used by the `android_feature_module` rule defined at `rules/android_application/android_feature_module_rule.bzl` to check if the manifest file is valid.