### PR TITLE
android_application: add the missing fused attribute for the android_…

### DIFF
--- a/rules/android_application/attrs.bzl
+++ b/rules/android_application/attrs.bzl
@@ -126,4 +126,5 @@ ANDROID_FEATURE_MODULE_ATTRS = dict(
         default = False,
         doc = "Marks the feature module as an asset module. This enables the module to be distributed as archive files rather than just as APKs. Cannot contain any dex or native code.",
     ),
+    fused = attr.bool(default = True),
 )


### PR DESCRIPTION
…feature_module rule

It's set in the `android_feature_module_macro` in
`rules/android_application/android_feature_module_rule.bzl`, and is read in the implementation of the `android_feature_module` rule defined in `rules/android_application/android_feature_module_rule.bzl`.