### PR TITLE
android_application: set the default _merge_manifests attribute corre…

### DIFF
--- a/rules/android_application/BUILD
+++ b/rules/android_application/BUILD
@@ -40,10 +40,3 @@ py_binary(
         "@py_absl//absl/flags",
     ],
 )
-
-filegroup(
-    name = "merge_feature_manifests.par",
-    srcs = [":merge_feature_manifests"],
-    output_group = "python_zip_file",
-    visibility = ["//visibility:public"],
-)

--- a/rules/android_application/attrs.bzl
+++ b/rules/android_application/attrs.bzl
@@ -81,8 +81,7 @@ ANDROID_APPLICATION_ATTRS = _attrs.add(
             default = Label("//tools/jdk:toolchain_android_only"),
         ),
         _merge_manifests = attr.label(
-            default = ":merge_feature_manifests.par",
-            allow_single_file = True,
+            default = ":merge_feature_manifests",
             cfg = "exec",
             executable = True,
         ),


### PR DESCRIPTION
…ctly

merge_feature_manifests.par is a zip file, and is not executable. Just use the original `py_binary` target. And since the `py_binary` target has multiple files, we remove `allow_single_file = True`.

We can keep the `merge_feature_manifests.par` target name via `alias` if that makes the life to sync between google3 and the OSS version easier.