### PR TITLE
Do not percent-encode '+' in classpath-jar manifest Class-Path entries

### DIFF
--- a/tools/jdk/java_stub_template.txt
+++ b/tools/jdk/java_stub_template.txt
@@ -315,14 +315,14 @@ function create_classpath_jar() {
   for path in ${CLASSPATH}; do
     # Loop through the characters of the path and convert characters that are
     # not alphanumeric nor -_.~/ to their 2-digit hexadecimal representation
-    if [[ ! $path =~ ^[-_.~/a-zA-Z0-9]*$ ]]; then
+    if [[ ! $path =~ ^[-_.~/a-zA-Z0-9+]*$ ]]; then
       local i c buff
       local converted_path=""
 
       for ((i=0; i<${#path}; i++)); do
         c=${path:$i:1}
         case ${c} in
-              [-_.~/a-zA-Z0-9] ) buff=${c} ;;
+              [-_.~/a-zA-Z0-9+] ) buff=${c} ;;
               * )               printf -v buff '%%%02x' "'$c'"
         esac
         converted_path+="${buff}"


### PR DESCRIPTION
Add '+' to the allowed character class so it passes through literally.

The java stub template packs over-long classpaths into a classpath jar whose manifest Class-Path entries percent-encode any character outside [-_.~/a-zA-Z0-9]. Bzlmod canonical repository names put '+' into every external-repo classpath entry, so those entries now contain "%2b" sequences. '+' is a valid URI path character and needs no encoding, and the "%2b" breaks consumers that pass classpath URLs through printf-style formatting