### PR TITLE
Support reading adb from the toolchain

### DIFF
--- a/mobile_install/launcher_direct.bzl
+++ b/mobile_install/launcher_direct.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Creates the app launcher scripts."""
 
+load("//rules:utils.bzl", "get_android_toolchain")
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
 load("//rules/flags:flags.bzl", "flags")
 load(":deploy_info.bzl", "make_deploy_info_pb")
@@ -75,6 +76,7 @@ def _make_app_runner(
     path_type = "path" if ctx.attr._mi_is_cmd else "short_path"
 
     deploy = utils.first(ctx.attr._deploy[DefaultInfo].files.to_list())
+    adb = get_android_toolchain(ctx).adb.files_to_run.executable
 
     args = {
         "is_cmd": str(ctx.attr._mi_is_cmd).lower(),
@@ -84,6 +86,9 @@ def _make_app_runner(
         args["splits"] = [getattr(s, path_type) for s in splits]
 
     args["java_home"] = utils.host_jvm_path(ctx)
+
+    if adb:
+        args["toolchain_adb"] = getattr(adb, path_type)
 
     args["studio_deployer"] = getattr(ctx.file._studio_deployer, path_type)
     args["use_adb_root"] = str(use_adb_root).lower()
@@ -108,6 +113,8 @@ def _make_app_runner(
     )
 
     runner = [deploy]
+    if adb:
+        runner.append(adb)
     return runner
 
 def make_direct_launcher(

--- a/src/tools/mi/broker/adb.go
+++ b/src/tools/mi/broker/adb.go
@@ -215,16 +215,24 @@ func (a *Controller) Pull(ctx context.Context, from, to string) error {
 
 // setupEnv determines which adb path to use and sets up the implicit environment settings required
 // and returns a prepared environment and the correct adb path.
-func setupEnv(ctx context.Context, env []string, adbPath string) (*ADB, error) {
+func setupEnv(ctx context.Context, env []string, adbPath, toolchainADBPath string) (*ADB, error) {
 	adbSource := "default"
-
-	// Find ANDROID_ADB entry from environment vars, if found set it as the path unless overridden.
 	adbEnv := &ADB{}
-	for _, entry := range env {
-		if strings.HasPrefix(entry, androidADBVar) {
-			adbEnv.Path = strings.TrimPrefix(entry, androidADBVar)
-			adbSource = "environment variable"
-			break
+
+	// The flag should always win
+	if adbPath != "" {
+		adbEnv.Path = adbPath
+		adbSource = "flag"
+	}
+
+	if adbEnv.Path == "" {
+		// Find ANDROID_ADB entry from environment vars, if found set it as the path unless overridden.
+		for _, entry := range env {
+			if strings.HasPrefix(entry, androidADBVar) {
+				adbEnv.Path = strings.TrimPrefix(entry, androidADBVar)
+				adbSource = "environment variable"
+				break
+			}
 		}
 	}
 
@@ -237,10 +245,9 @@ func setupEnv(ctx context.Context, env []string, adbPath string) (*ADB, error) {
 		}
 	}
 
-	// The flag should always win
-	if adbPath != "" {
-		adbEnv.Path = adbPath
-		adbSource = "flag"
+	if adbEnv.Path == "" && toolchainADBPath != "" {
+		adbEnv.Path = toolchainADBPath
+		adbSource = "toolchain"
 	}
 
 	// Fallback to default pre-installed adb, if it exists, or fail if not found.
@@ -258,8 +265,8 @@ func setupEnv(ctx context.Context, env []string, adbPath string) (*ADB, error) {
 
 // New creates a new adb Controller.
 // If more than once device is available, deviceFlag must be specified.
-func New(ctx context.Context, env []string, deviceSerial, adbPort, adbPath string, useADBRoot bool) (*Controller, error) {
-	a, err := setupEnv(ctx, env, adbPath)
+func New(ctx context.Context, env []string, deviceSerial, adbPort, adbPath, toolchainADBPath string, useADBRoot bool) (*Controller, error) {
+	a, err := setupEnv(ctx, env, adbPath, toolchainADBPath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/tools/mi/broker/adb_test.go
+++ b/src/tools/mi/broker/adb_test.go
@@ -22,13 +22,14 @@ import (
 )
 
 func TestSetupEnv(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
 	tcs := []struct {
-		name         string
-		env          []string
-		adbPath      string
-		adbTurboPath string
-		wantPath     string
-		wantEnv      []string
+		name             string
+		env              []string
+		adbPath          string
+		toolchainADBPath string
+		wantPath         string
+		wantEnv          []string
 	}{
 		/*
 			Following test cases fail due to the os.stat check need refactor
@@ -54,11 +55,26 @@ func TestSetupEnv(t *testing.T) {
 			env:      []string{androidADBVar + "/my/adb"},
 			wantPath: "/my/adb",
 			wantEnv:  []string{}, // Expect the env entry to be removed, which produces an empty list.
+		}, {
+			name:             "SpecifyADBPathOverridesEnvAndToolchain",
+			env:              []string{androidADBVar + "/env/adb"},
+			adbPath:          "/flag/adb",
+			toolchainADBPath: "/toolchain/adb",
+			wantPath:         "/flag/adb",
+		}, {
+			name:             "SpecifyADBPathViaEnvOverridesToolchain",
+			env:              []string{androidADBVar + "/env/adb"},
+			toolchainADBPath: "/toolchain/adb",
+			wantPath:         "/env/adb",
+		}, {
+			name:             "SpecifyADBPathViaToolchain",
+			toolchainADBPath: "/toolchain/adb",
+			wantPath:         "/toolchain/adb",
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			ae, err := setupEnv(context.Background(), tc.env, tc.adbPath)
+			ae, err := setupEnv(context.Background(), tc.env, tc.adbPath, tc.toolchainADBPath)
 			if err != nil {
 				t.Fatalf("error occurred, got: %v", err)
 			}

--- a/src/tools/mi/broker/device.go
+++ b/src/tools/mi/broker/device.go
@@ -48,6 +48,7 @@ type Controller interface {
 // Device holds information of a particular android device.
 type Device struct {
 	Ctl      Controller
+	ADBPath  string
 	abis     []string
 	Props    map[string]string
 	userOnce sync.Once
@@ -59,10 +60,14 @@ type Device struct {
 }
 
 // New creates and returns a new Device.
-func New(ctx context.Context, deviceSerial, port, tmpDir string, adbPath string, useADBRoot bool) (*Device, error) {
-	ctl, err := initDeviceController(ctx, adbPath, deviceSerial, port, useADBRoot)
+func New(ctx context.Context, deviceSerial, port, tmpDir string, adbPath, toolchainADBPath string, useADBRoot bool) (*Device, error) {
+	ctl, err := initDeviceController(ctx, adbPath, toolchainADBPath, deviceSerial, port, useADBRoot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize device controller %v", err)
+	}
+	selectedADBPath := ""
+	if adbCtl, ok := ctl.(*adb.Controller); ok {
+		selectedADBPath = adbCtl.Path
 	}
 	props, err := getProp(ctx, ctl)
 	if err != nil {
@@ -85,7 +90,7 @@ func New(ctx context.Context, deviceSerial, port, tmpDir string, adbPath string,
 	if abis == "" {
 		return nil, errors.New("unable to get supported ABIs from device")
 	}
-	d := &Device{Ctl: ctl, tmpDir: tmpDir, APILevel: apiLevel, ABI: abi, ABIs: strings.Split(abis, ",")}
+	d := &Device{Ctl: ctl, ADBPath: selectedADBPath, tmpDir: tmpDir, APILevel: apiLevel, ABI: abi, ABIs: strings.Split(abis, ",")}
 	return d, nil
 }
 
@@ -181,10 +186,10 @@ func parseProperties(in string) (map[string]string, error) {
 	return props, nil
 }
 
-func initDeviceController(ctx context.Context, adbPath string, deviceSerial, port string, useADBRoot bool) (Controller, error) {
+func initDeviceController(ctx context.Context, adbPath, toolchainADBPath string, deviceSerial, port string, useADBRoot bool) (Controller, error) {
 	var ctl Controller
 	var err error
-	ctl, err = adb.New(ctx, os.Environ(), deviceSerial, port, adbPath, useADBRoot)
+	ctl, err = adb.New(ctx, os.Environ(), deviceSerial, port, adbPath, toolchainADBPath, useADBRoot)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to connect to device: %v", err)
 	}

--- a/src/tools/mi/deployment/deploy_binary.go
+++ b/src/tools/mi/deployment/deploy_binary.go
@@ -32,18 +32,19 @@ import (
 )
 
 var (
-	adbArgs        = flags.NewStringList("adb_arg", "Options for the adb binary.")
-	adbPath        = flag.String("adb", "", "Path to the adb binary to use with mobile-install.")
-	device         = flag.String("device", "", "The adb device serial number.")
-	javaHome       = flag.String("java_home", "", "Path to JDK.")
-	launchActivity = flag.String("launch_activity", "", "Activity to launch via am start -n package/.activity_to_launch.")
-	appPackagePath = flag.String("manifest_package_name_path", "", "Path to file containing the manifest package name.")
-	splits         = flags.NewStringList("splits", "The list of split apk paths.")
-	start          = flag.String("start", "", "start_type from mobile-install.")
-	startType      = flag.String("start_type", "", "start_type (deprecated, use --start).")
-	toolTag        = flag.String("tool_tag", "", "tool_tag from blaze.")
-	useADBRoot     = flag.Bool("use_adb_root", true, "whether (true) or not (false) to use root permissions.")
-	userID         = flag.Int("user", 0, "User id to install the app for.")
+	adbArgs          = flags.NewStringList("adb_arg", "Options for the adb binary.")
+	adbPath          = flag.String("adb", "", "Path to the adb binary to use with mobile-install.")
+	toolchainADBPath = flag.String("toolchain_adb", "", "Path to the adb binary from the Android toolchain.")
+	device           = flag.String("device", "", "The adb device serial number.")
+	javaHome         = flag.String("java_home", "", "Path to JDK.")
+	launchActivity   = flag.String("launch_activity", "", "Activity to launch via am start -n package/.activity_to_launch.")
+	appPackagePath   = flag.String("manifest_package_name_path", "", "Path to file containing the manifest package name.")
+	splits           = flags.NewStringList("splits", "The list of split apk paths.")
+	start            = flag.String("start", "", "start_type from mobile-install.")
+	startType        = flag.String("start_type", "", "start_type (deprecated, use --start).")
+	toolTag          = flag.String("tool_tag", "", "tool_tag from blaze.")
+	useADBRoot       = flag.Bool("use_adb_root", true, "whether (true) or not (false) to use root permissions.")
+	userID           = flag.Int("user", 0, "User id to install the app for.")
 
 	// Studio deployer args
 	studioDeployerPath = flag.String("studio_deployer", "", "Path to the Android Studio deployer.")
@@ -165,7 +166,7 @@ func main() {
 	}
 
 	pprint.Info("Connecting to device %s", deviceSerial)
-	d, err := devlib.New(ctx, deviceSerial, port, devTmp, *adbPath, *useADBRoot)
+	d, err := devlib.New(ctx, deviceSerial, port, devTmp, *adbPath, *toolchainADBPath, *useADBRoot)
 	if err != nil {
 		glog.Exitln(err)
 	}
@@ -178,7 +179,7 @@ func main() {
 	startTime := time.Now()
 
 	pprint.Info("Installing application using the Android Studio deployer ...")
-	if err := deployment.AndroidStudioSync(ctx, deviceSerial, port, appPackage, *splits, *studioDeployerPath, *adbPath, *javaHome, *optimisticInstall, *studioVerboseLog, *userID, *useADBRoot); err != nil {
+	if err := deployment.AndroidStudioSync(ctx, deviceSerial, port, appPackage, *splits, *studioDeployerPath, d.ADBPath, *javaHome, *optimisticInstall, *studioVerboseLog, *userID, *useADBRoot); err != nil {
 		flushAndExitf(ctx, "", "", "", "", "Got error installing using the Android Studio deployer: %v", err)
 	}
 


### PR DESCRIPTION
This makes it so you aren't required to include the `platform-tools` in
your `PATH` just for `adb`
