### PR TITLE
Remove -Drunfiles.path for Windows

### DIFF
--- a/src/tools/java/com/google/devtools/build/android/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/BUILD
@@ -28,7 +28,6 @@ java_binary(
     # recent example, 400 MB of memory was enough for about 500,000 entries.
     jvm_flags = [
         "-Xmx1600m",
-        "-Drunfiles.path=$$0.runfiles",
         "-Dsinglejar.path=$(rlocationpath //tools/jdk:singlejar)",
     ],
     main_class = "com.google.devtools.build.android.ZipFilterAction",
@@ -102,6 +101,7 @@ java_library(
         "@rules_android_maven//:com_google_code_findbugs_jsr305",
         "@rules_android_maven//:com_google_errorprone_error_prone_annotations",
         "@rules_android_maven//:com_google_guava_guava",
+        "@rules_java//java/runfiles",
         ":android_common_30_1_3",
         ":android_databinding_wrapper_lib",
         ":android_options_utils",

--- a/src/tools/java/com/google/devtools/build/android/ZipFilterAction.java
+++ b/src/tools/java/com/google/devtools/build/android/ZipFilterAction.java
@@ -27,6 +27,7 @@ import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
+import com.google.devtools.build.runfiles.Runfiles;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -305,9 +306,7 @@ public class ZipFilterAction {
       throw new IllegalArgumentException("FORCE_DEFLATE is not supported.");
     }
 
-    String singleJarPath =
-        Path.of(System.getProperty("runfiles.path"), System.getProperty("singlejar.path"))
-            .toString();
+    String singleJarPath = resolveSingleJarPath();
     ImmutableList.Builder<String> singleJarArgsBuilder = ImmutableList.builder();
     singleJarArgsBuilder
         .add("--sources")
@@ -366,5 +365,24 @@ public class ZipFilterAction {
     logger.fine(String.format("Filtering completed in %dms", timer.elapsed(TimeUnit.MILLISECONDS)));
 
     return sawErrors;
+  }
+
+  private static String resolveSingleJarPath() throws IOException {
+    String singleJarPath = System.getProperty("singlejar.path");
+    if (singleJarPath == null || singleJarPath.isEmpty()) {
+      throw new IOException("Missing singlejar.path system property.");
+    }
+
+    Path directPath = Path.of(singleJarPath);
+    if (directPath.isAbsolute() && Files.exists(directPath)) {
+      return directPath.toString();
+    }
+
+    String resolvedPath = Runfiles.create().rlocation(singleJarPath);
+    if (resolvedPath != null) {
+      return resolvedPath;
+    }
+
+    throw new IOException("Could not resolve singlejar runfile: " + singleJarPath);
   }
 }

--- a/src/tools/java/com/google/devtools/build/android/ZipFilterAction.java
+++ b/src/tools/java/com/google/devtools/build/android/ZipFilterAction.java
@@ -310,9 +310,9 @@ public class ZipFilterAction {
     ImmutableList.Builder<String> singleJarArgsBuilder = ImmutableList.builder();
     singleJarArgsBuilder
         .add("--sources")
-        .add(options.inputZip.toString())
+        .add(singleJarParamPath(options.inputZip))
         .add("--output")
-        .add(options.outputZip.toString())
+        .add(singleJarParamPath(options.outputZip))
         .add(compressionStrategy)
         .add("--exclude_build_data")
         .add("--normalize");
@@ -384,5 +384,10 @@ public class ZipFilterAction {
     }
 
     throw new IOException("Could not resolve singlejar runfile: " + singleJarPath);
+  }
+
+  @VisibleForTesting
+  static String singleJarParamPath(Path path) {
+    return path.toString().replace('\\', '/');
   }
 }

--- a/src/tools/javatests/com/google/devtools/build/android/BUILD
+++ b/src/tools/javatests/com/google/devtools/build/android/BUILD
@@ -369,7 +369,6 @@ java_test(
         "//tools/jdk:singlejar",
     ],
     jvm_flags = [
-        "-Drunfiles.path=$$TEST_SRCDIR",
         "-Dsinglejar.path=$(rlocationpath //tools/jdk:singlejar)",
     ],
     deps = [

--- a/src/tools/javatests/com/google/devtools/build/android/ZipFilterActionTest.java
+++ b/src/tools/javatests/com/google/devtools/build/android/ZipFilterActionTest.java
@@ -161,6 +161,18 @@ public class ZipFilterActionTest {
     ZipFilterAction.run(args.toArray(new String[0]));
   }
 
+  @Test
+  public void singleJarParamPath_normalizesWindowsSeparators() {
+    assertThat(
+            ZipFilterAction.singleJarParamPath(
+                Path.of(
+                    "bazel-out\\x64_windows-fastbuild\\bin\\tests\\emulator_instrumentation\\"
+                        + "instrumentation_app_deploy.jar")))
+        .isEqualTo(
+            "bazel-out/x64_windows-fastbuild/bin/tests/emulator_instrumentation/"
+                + "instrumentation_app_deploy.jar");
+  }
+
   @Test public void testFullIntegration() throws IOException {
     Path input = createZip(new Entry("foo.java", "foo"), new Entry("bar.class", "bar"),
         new Entry("baz.class", "baz"), new Entry("1.class", "1"), new Entry("2.class", "2"),


### PR DESCRIPTION
On windows this $$0.runfiles thing didn't work. We can use the runfiles
API instead
