### PR TITLE
Add `use_minimal_keep_rules` flag for aapt2 minimal proguard keep rules

### DIFF
--- a/rules/android_binary/impl.bzl
+++ b/rules/android_binary/impl.bzl
@@ -107,6 +107,7 @@ def _process_resources(ctx, manifest_ctx, java_package, **unused_ctxs):
         shrink_resources = ctx.attr.shrink_resources,
         use_android_resource_shrinking = ctx.fragments.android.use_android_resource_shrinking,
         use_android_resource_cycle_shrinking = ctx.fragments.android.use_android_resource_cycle_shrinking,
+        use_minimal_keep_rules = _flags.get(ctx).use_minimal_keep_rules,
         use_legacy_manifest_merger = use_legacy_manifest_merger(ctx),
         should_throw_on_conflict = not acls.in_allow_resource_conflicts(str(ctx.label)),
         enable_data_binding = ctx.attr.enable_data_binding,

--- a/rules/busybox.bzl
+++ b/rules/busybox.bzl
@@ -234,6 +234,7 @@ def _package(
         nocompress_extensions = [],
         proto_format = False,
         shrink_resource_cycles = False,
+        use_minimal_keep_rules = False,
         version_name = None,
         version_code = None,
         feature_flags = "",
@@ -293,6 +294,9 @@ def _package(
       proto_format: Boolean, whether to generate the resource table in proto format.
       shrink_resource_cycles: Boolean, flag that enables more shrinking of
         code and resources by instructing AAPT2 to emit conditional Proguard keep rules.
+      use_minimal_keep_rules: Boolean, flag that instructs AAPT2 to emit minimal Proguard
+        keep rules with precise member signatures instead of broad <init>(...) rules,
+        matching Android Gradle Plugin behavior.
       version_name: A string. The version name to stamp the generated manifest with. Optional.
       version_code: A string. The version code to stamp the generated manifest with. Optional.
       crunch_png: A boolean. Determines whether `aapt2 compile` should crunch PNG files.
@@ -414,6 +418,8 @@ def _package(
         args.add("--resourceTableAsProto")
     if shrink_resource_cycles:
         args.add("--conditionalKeepRules=yes")
+    if use_minimal_keep_rules:
+        args.add("--minimalKeepRules=yes")
     if version_name:
         args.add("--versionName", version_name)
     if version_code:

--- a/rules/flags/flag_defs.bzl
+++ b/rules/flags/flag_defs.bzl
@@ -108,3 +108,12 @@ def define_flags():
         description = "When enabled, aar_import extracts R8-targeted proguard rules from " +
                       "META-INF/com.android.tools/ inside classes.jar in addition to proguard.txt.",
     )
+
+    flags.DEFINE_bool(
+        name = "use_minimal_keep_rules",
+        default = False,
+        description = "When enabled, aapt2 generates minimal proguard keep rules " +
+                      "(--proguard-minimal-keep-rules) for resources: precise member " +
+                      "signatures (e.g. constructor argument types) instead of broad " +
+                      "<init>(...) rules, matching Android Gradle Plugin behavior.",
+    )

--- a/rules/resources.bzl
+++ b/rules/resources.bzl
@@ -487,6 +487,7 @@ def _package(
         shrink_resources = None,
         use_android_resource_shrinking = None,
         use_android_resource_cycle_shrinking = None,
+        use_minimal_keep_rules = False,
         use_legacy_manifest_merger = False,
         should_throw_on_conflict = True,
         enable_data_binding = False,
@@ -547,6 +548,9 @@ def _package(
         shrink_resources if the tristate value is auto (-1).
       use_android_resource_cycle_shrinking: Bool. Flag that enables more shrinking of
         code and resources by instructing AAPT2 to emit conditional Proguard keep rules.
+      use_minimal_keep_rules: Bool. Flag that instructs AAPT2 to emit minimal Proguard
+        keep rules with precise member signatures instead of broad <init>(...) rules,
+        matching Android Gradle Plugin behavior.
       use_legacy_manifest_merger: A boolean. Whether to use the legacy manifest merger
       instead of the android manifest merger.
       should_throw_on_conflict: A boolean. Determines whether an error should be thrown
@@ -768,6 +772,7 @@ def _package(
         nocompress_extensions = nocompress_extensions,
         java_package = java_package,
         shrink_resource_cycles = shrink_resource_cycles,
+        use_minimal_keep_rules = use_minimal_keep_rules,
         version_name = manifest_values[_VERSION_NAME] if _VERSION_NAME in manifest_values else None,
         version_code = manifest_values[_VERSION_CODE] if _VERSION_CODE in manifest_values else None,
         feature_flags = feature_flags,

--- a/src/tools/java/com/google/devtools/build/android/Aapt2ResourcePackagingAction.java
+++ b/src/tools/java/com/google/devtools/build/android/Aapt2ResourcePackagingAction.java
@@ -405,6 +405,7 @@ public class Aapt2ResourcePackagingAction {
               .withAssets(assetDirs)
               .buildVersion(aaptConfigOptions.buildToolsVersion)
               .conditionalKeepRules(aaptConfigOptions.conditionalKeepRules == TriState.YES)
+              .minimalKeepRules(aaptConfigOptions.minimalKeepRules == TriState.YES)
               .filterToDensity(options.densities)
               .storeUncompressed(aaptConfigOptions.uncompressedExtensions)
               .debug(aaptConfigOptions.debug)

--- a/src/tools/java/com/google/devtools/build/android/aapt2/Aapt2ConfigOptions.java
+++ b/src/tools/java/com/google/devtools/build/android/aapt2/Aapt2ConfigOptions.java
@@ -69,6 +69,14 @@ public class Aapt2ConfigOptions {
   public TriState conditionalKeepRules = TriState.AUTO;
 
   @Parameter(
+      names = "--minimalKeepRules",
+      description =
+          "Have AAPT2 produce minimal proguard keep rules, emitting precise member "
+              + "signatures (e.g. constructor argument types) instead of broad <init>(...) "
+              + "rules. Matches Android Gradle Plugin behavior.")
+  public TriState minimalKeepRules = TriState.AUTO;
+
+  @Parameter(
       names = "--uncompressedExtensions",
       description = "A list of file extensions not to compress.")
   public List<String> uncompressedExtensions = ImmutableList.of();

--- a/src/tools/java/com/google/devtools/build/android/aapt2/ResourceLinker.java
+++ b/src/tools/java/com/google/devtools/build/android/aapt2/ResourceLinker.java
@@ -166,6 +166,7 @@ public class ResourceLinker {
   private List<CompiledResources> include = ImmutableList.of();
   private List<Path> assetDirs = ImmutableList.of();
   private boolean conditionalKeepRules = false;
+  private boolean minimalKeepRules = false;
   private boolean includeProguardLocationReferences = false;
   private List<StaticLibrary> resourceApks = ImmutableList.of();
   private String featureFlags = "";
@@ -230,6 +231,12 @@ public class ResourceLinker {
   @CanIgnoreReturnValue
   public ResourceLinker conditionalKeepRules(boolean conditionalKeepRules) {
     this.conditionalKeepRules = conditionalKeepRules;
+    return this;
+  }
+
+  @CanIgnoreReturnValue
+  public ResourceLinker minimalKeepRules(boolean minimalKeepRules) {
+    this.minimalKeepRules = minimalKeepRules;
     return this;
   }
 
@@ -529,6 +536,8 @@ public class ResourceLinker {
             .add("--no-proguard-location-reference")
             .when(conditionalKeepRules)
             .thenAdd("--proguard-conditional-keep-rules")
+            .when(minimalKeepRules)
+            .thenAdd("--proguard-minimal-keep-rules")
             .add("-o", linked)
             .add("--feature-flags", featureFlags)
             .execute(String.format("Linking %s", compiled.getManifest())));


### PR DESCRIPTION

## Problem

aapt2 generates broad resource keep rules by default. Bazel and Gradle produce different rules for the same target:

```
# Bazel (current)
-keep class androidx.appcompat.widget.AlertDialogLayout { <init>(...); }

# Gradle
-keep class androidx.appcompat.widget.AlertDialogLayout { <init>(android.content.Context, android.util.AttributeSet); }
```

Gradle passes `--proguard-minimal-keep-rules` to aapt2, emitting precise member signatures. Bazel does not, so keep rules (and shrinking output) diverge.

## Change

Add opt-in flag `use_minimal_keep_rules`. When enabled, aapt2 `link` receives `--proguard-minimal-keep-rules`, matching Gradle.

Off by default. Enable with:

```
build --define=use_minimal_keep_rules=true
```

Mirrors the existing `conditionalKeepRules` / `--proguard-conditional-keep-rules` path.
