### PR TITLE
Use ijar:zipper instead of host zip/unzip for hermetic RBE builds

### DIFF
--- a/rules/aar_import/attrs.bzl
+++ b/rules/aar_import/attrs.bzl
@@ -13,12 +13,12 @@
 # limitations under the License.
 """Attributes."""
 
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load(
     "//rules:attrs.bzl",
     _attrs = "attrs",
 )
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
-load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 
 visibility(PROJECT_VISIBILITY)
 
@@ -70,6 +70,10 @@ ATTRS = _attrs.add(
             cfg = "exec",
             default = Label("//tools/jdk:current_java_runtime"),
         ),
+        _hermetic_zipper = attr.label(
+            cfg = "exec",
+            default = "@bazel_tools//third_party/ijar:zipper",
+        ),
         _manifest_merge_order = attr.label(
             default = "//rules/flags:manifest_merge_order",
         ),
@@ -82,9 +86,9 @@ ATTRS = _attrs.add(
                 # https://developer.android.com/studio/projects/android-library#aar-contents
                 "@platforms//cpu:arm64": "arm64-v8a",
                 "@platforms//cpu:armv7": "armeabi-v7a",
+                "@platforms//cpu:riscv64": "riscv64",
                 "@platforms//cpu:x86_32": "x86",
                 "@platforms//cpu:x86_64": "x86_64",
-                "@platforms//cpu:riscv64": "riscv64",
             },
         ),
     ),

--- a/rules/aar_import/impl.bzl
+++ b/rules/aar_import/impl.bzl
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Implementation."""
 
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("@rules_java//java/common:proguard_spec_info.bzl", "ProguardSpecInfo")
 load("//providers:providers.bzl", "AndroidLintRulesInfo", "AndroidNativeLibsInfo")
 load(
     "//rules:acls.bzl",
@@ -41,9 +44,7 @@ load(
 )
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
 load("//rules/flags:flags.bzl", "read_possibly_native_flag", _flags = "flags")
-load("@rules_java//java/common:java_common.bzl", "java_common")
-load("@rules_java//java/common:java_info.bzl", "JavaInfo")
-load("@rules_java//java/common:proguard_spec_info.bzl", "ProguardSpecInfo")
+load("//toolchains/android:zipper.bzl", "zipper_extract")
 
 visibility(PROJECT_VISIBILITY)
 
@@ -64,26 +65,36 @@ def extract_single_file(
         out_file,
         aar,
         filename,
-        unzip_tool,
         create_empty_file = False):
+    """Extract a single file from an AAR archive.
+
+    Args:
+      ctx: The rule context.
+      out_file: Output file to create.
+      aar: Input AAR archive.
+      filename: Name of the file to extract from the AAR.
+      create_empty_file: Whether to create an empty file if missing.
+    """
+    if create_empty_file:
+        fail("hermetic aar_import does not support create_empty_file=True")
+    extracted = ctx.actions.declare_directory(
+        out_file.dirname + "/extract_" + filename.replace("/", "_"),
+    )
+    zipper_extract(
+        ctx,
+        archive = aar,
+        output_dir = extracted,
+        entries = [filename],
+        mnemonic = "AarFileExtractZip",
+    )
     ctx.actions.run_shell(
-        tools = [unzip_tool],
-        inputs = [aar],
+        inputs = [extracted],
         outputs = [out_file],
-        command =
-            """
-            if ! {create_empty_file} || {unzip_tool} -l {aar} | grep -q {file}; then
-              {unzip_tool} -q {aar} {file} -d {dirname};
-           else
-               touch {dirname}/{file};
-           fi
-        """.format(
-                unzip_tool = unzip_tool.executable.path,
-                aar = aar.path,
-                file = out_file.basename,
-                dirname = out_file.dirname,
-                create_empty_file = str(create_empty_file).lower(),
-            ),
+        command = "cp '{src}/{file}' '{out}'".format(
+            src = extracted.path,
+            file = filename,
+            out = out_file.path,
+        ),
         mnemonic = "AarFileExtractor",
         progress_message = "Extracting %s from %s" % (filename, aar.basename),
         toolchain = ANDROID_TOOLCHAIN_TYPE,
@@ -396,8 +407,7 @@ def _validate_rule(
 
 def _process_lint_rules(
         ctx,
-        aar,
-        unzip_tool):
+        aar):
     transitive_lint_jars = [info.lint_jars for info in _utils.collect_providers(
         AndroidLintRulesInfo,
         ctx.attr.exports,
@@ -410,7 +420,6 @@ def _process_lint_rules(
             lint_jar,
             aar,
             LINT_JAR,
-            unzip_tool,
         )
         return [
             AndroidLintRulesInfo(
@@ -462,7 +471,6 @@ def impl(ctx):
     validation_outputs = []
 
     aar = _utils.only(ctx.files.aar)
-    unzip_tool = _get_android_toolchain(ctx).unzip_tool.files_to_run
     package = _java.resolve_package_from_label(ctx.label, ctx.attr.package)
 
     # Extract the AndroidManifest.xml from the AAR.
@@ -472,7 +480,6 @@ def impl(ctx):
         android_manifest,
         aar,
         ANDROID_MANIFEST,
-        unzip_tool,
     )
 
     # Bump min SDK to floor
@@ -572,7 +579,6 @@ def impl(ctx):
     lint_providers = _process_lint_rules(
         ctx,
         aar = aar,
-        unzip_tool = unzip_tool,
     )
     providers.extend(lint_providers)
 

--- a/rules/common.bzl
+++ b/rules/common.bzl
@@ -13,10 +13,11 @@
 # limitations under the License.
 """Bazel common library for the Android rules."""
 
-load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
-load("//rules/android_common:reexport_android_common.bzl", _native_android_common = "native_android_common")
 load("@rules_java//java/common:java_common.bzl", "java_common")
 load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
+load("//rules/android_common:reexport_android_common.bzl", _native_android_common = "native_android_common")
+load("//toolchains/android:zipper.bzl", "run_filter_zip_include")
 load(":utils.bzl", "ANDROID_TOOLCHAIN_TYPE", "get_android_toolchain", _log = "log")
 
 visibility(PROJECT_VISIBILITY)
@@ -46,21 +47,12 @@ def _get_host_javabase(ctx):
 
 def _filter_zip_include(ctx, in_zip, out_zip, filters = []):
     """Creates a copy of a zip file with files that match filters."""
-    args = ctx.actions.args()
-    args.add("-q")
-    args.add(in_zip.path)
-    args.add_all(filters)
-    args.add("--copy")
-    args.add("--out")
-    args.add(out_zip.path)
-    ctx.actions.run(
-        executable = get_android_toolchain(ctx).zip_tool.files_to_run,
-        arguments = [args],
-        inputs = [in_zip],
-        outputs = [out_zip],
-        mnemonic = "FilterZipInclude",
-        progress_message = "Filtering %s" % in_zip.short_path,
-        toolchain = ANDROID_TOOLCHAIN_TYPE,
+    run_filter_zip_include(
+        ctx,
+        input_zip = in_zip,
+        output_zip = out_zip,
+        filters = filters,
+        zipper_target = get_android_toolchain(ctx).zip_tool,
     )
 
 def _filter_zip_exclude(

--- a/rules/resources.bzl
+++ b/rules/resources.bzl
@@ -13,14 +13,15 @@
 # limitations under the License.
 """Bazel Android Resources."""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
 load("//providers:providers.bzl", "AndroidLibraryResourceClassJarProvider", "ResourcesNodeInfo", "StarlarkAndroidResourcesInfo")
 load("//rules:acls.bzl", "acls")
 load("//rules:add_constraints.bzl", "add_constraints")
 load("//rules:min_sdk_version.bzl", _min_sdk_version = "min_sdk_version")
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
 load("//rules/flags:flags.bzl", "read_possibly_native_flag")
-load("@rules_java//java/common:java_info.bzl", "JavaInfo")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("//toolchains/android:zipper.bzl", "zipper_resolve_bash")
 load(":attrs.bzl", _attrs = "attrs")
 load(":busybox.bzl", _busybox = "busybox")
 load(":path.bzl", _path = "path")
@@ -357,59 +358,60 @@ def _fix_databinding_compiled_resources(
       ctx: The context.
       out_compiled_resources: File. The modified compiled_resources output.
       compiled_resources: File. The compiled_resources zip.
-      zip_tool: FilesToRunProvider. The zip tool executable or FilesToRunProvider
+      zip_tool: FilesToRunProvider. Hermetic ijar:zipper executable.
     """
+    resolve = zipper_resolve_bash(zip_tool, "ZIPPER")
     ctx.actions.run_shell(
         outputs = [out_compiled_resources],
         inputs = [compiled_resources],
         tools = [zip_tool],
-        arguments = [compiled_resources.path, out_compiled_resources.path, zip_tool.executable.path],
+        arguments = [compiled_resources.path, out_compiled_resources.path],
         toolchain = None,
         mnemonic = "FixDatabindingCompiledResources",
-        command = """#!/bin/bash
+        command = resolve + """#!/bin/bash
 set -e
 
 IN_DIR=$(mktemp -d)
 OUT_DIR=$(mktemp -d)
 CUR_PWD=$(pwd)
+ARCHIVE="$1"
+OUT="$2"
+[[ "${ARCHIVE}" != /* ]] && ARCHIVE="${CUR_PWD}/${ARCHIVE}"
+[[ "${OUT}" != /* ]] && OUT="${CUR_PWD}/${OUT}"
 
-if zipinfo -t "$1"; then
-    # Use awk instead of 'head -n -2' for macOS compatibility (BSD head doesn't support negative counts)
-    ORDERED_LIST=`(unzip -l "$1" | sed -e '1,3d' | awk '{lines[NR]=$0} END{for(i=1;i<=NR-2;i++) print lines[i]}' | tr -s " " | cut -d " " -f5)`
+if "${ZIPPER}" v "${ARCHIVE}" >/dev/null 2>&1; then
+    ORDERED_LIST=`("${ZIPPER}" v "${ARCHIVE}" | awk '$1 == "f" {print $3}')`
 
-    unzip -q "$1" -d "$IN_DIR"
+    ( cd "$IN_DIR" && "${ZIPPER}" x "${ARCHIVE}" )
 
-    # Iterate through the ordered list, change "Databinding" to "databinding" in the file header
-    # and file name and zip the files with the right comment
     for FILE in $ORDERED_LIST; do
         cd "$IN_DIR"
         if [ -f "$FILE" ]; then
-            # Use sed with backup extension for macOS compatibility, then remove backup
             sed -i.bak 's/Databinding\\-processed\\-resources/databinding\\-processed\\-resources/g' "$FILE" && rm -f "$FILE.bak"
             NEW_NAME=`echo "$FILE" | sed 's/Databinding\\-processed\\-resources/databinding\\-processed\\-resources/g' | sed 's#'"$IN_DIR"'/##g'`
             mkdir -p `dirname "$OUT_DIR/$NEW_NAME"` && touch "$OUT_DIR/$NEW_NAME"
             cp -p "$FILE" "$OUT_DIR/$NEW_NAME"
-
-            PATH_SEGMENTS=(`echo ${FILE} | tr '/' ' '`)
-            BASE_PATH_SEGMENT="${PATH_SEGMENTS[0]}"
-                COMMENT=
-            if [ "${BASE_PATH_SEGMENT}" == "generated" ]; then
-                COMMENT="generated"
-            elif [ "${BASE_PATH_SEGMENT}" == "default" ]; then
-                COMMENT="default"
-            fi
-
-            cd "$OUT_DIR"
-            "$CUR_PWD/$3" -jt -X -0 -q -r -c "$CUR_PWD/$2" $NEW_NAME <<EOM
-${COMMENT}
-EOM
         fi
     done
 
+    cd "$OUT_DIR"
+    args=()
+    while IFS= read -r -d '' f; do
+      relpath=${f#./}
+      args+=("${relpath}=${f}")
+    done < <(find . -type f -print0)
+    if [ ${#args[@]} -eq 0 ]; then
+      empty=$(mktemp)
+      : >"${empty}"
+      "${ZIPPER}" c "${OUT}" "empty=${empty}"
+    else
+      "${ZIPPER}" c "${OUT}" "${args[@]}"
+    fi
+
     cd "$CUR_PWD"
-    touch -r "$1" "$2"
+    touch -r "${ARCHIVE}" "${OUT}"
 else
-    cp -p "$1" "$2"
+    cp -p "${ARCHIVE}" "${OUT}"
 fi
         """,
     )

--- a/src/tools/java/com/google/devtools/build/android/proto/BUILD
+++ b/src/tools/java/com/google/devtools/build/android/proto/BUILD
@@ -25,7 +25,8 @@ java_proto_library(
         name = proto + "_proto_file",
         srcs = ["@rules_android_maven//:com_android_tools_build_aapt2_proto"],
         outs = [proto + ".proto"],
-        cmd = "unzip -q $< " + proto + ".proto && " +
+        tools = ["@bazel_tools//third_party/ijar:zipper"],
+        cmd = "$(location @bazel_tools//third_party/ijar:zipper) x $< " + proto + ".proto && " +
               "sed 's/import \\\"/import \\\"src\\/tools\\/java\\/com\\/google\\/devtools\\/build\\/android\\/proto\\//' " + proto + ".proto > $@",
     )
     for proto in [

--- a/toolchains/android/BUILD
+++ b/toolchains/android/BUILD
@@ -2,7 +2,6 @@
 #   Defines the Android toolchain.
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load(":toolchain.bzl", "android_toolchain")
 
 licenses(["notice"])
@@ -35,24 +34,16 @@ bzl_library(
     srcs = glob(["*.bzl"]),
 )
 
-genrule(
-    name = "gen_unzip",
-    outs = ["unzip.sh"],
-    cmd = """cat > $@ <<EOF
-unzip \\$$@
-EOF
-""",
-    executable = True,
-)
+_ZIPPER = "@bazel_tools//third_party/ijar:zipper"
 
-sh_binary(
+alias(
     name = "zip",
-    srcs = [":zip.sh"],
+    actual = _ZIPPER,
     visibility = ["//visibility:public"],
 )
 
-sh_binary(
+alias(
     name = "unzip",
-    srcs = [":unzip.sh"],
+    actual = _ZIPPER,
     visibility = ["//visibility:public"],
 )

--- a/toolchains/android/toolchain.bzl
+++ b/toolchains/android/toolchain.bzl
@@ -250,7 +250,6 @@ _ATTRS = dict(
         allow_files = True,
         default = "//rules:robolectric_properties_template.txt",
     ),
-
     shuffle_jars = attr.label(
         cfg = "exec",
         default = Label("//tools/android:shuffle_jars"),
@@ -261,7 +260,7 @@ _ATTRS = dict(
     ),
     unzip_tool = attr.label(
         cfg = "exec",
-        default = "//toolchains/android:unzip",
+        default = "@bazel_tools//third_party/ijar:zipper",
         executable = True,
     ),
     xmllint_tool = attr.label(
@@ -278,7 +277,7 @@ _ATTRS = dict(
     ),
     zip_tool = attr.label(
         cfg = "exec",
-        default = "//toolchains/android:zip",
+        default = "@bazel_tools//third_party/ijar:zipper",
         executable = True,
     ),
     zip_filter = attr.label(
@@ -317,10 +316,10 @@ _ATTRS = dict(
         executable = True,
     ),
     deploy_info_writer = attr.label(
-      allow_single_file = True,
-      cfg = "exec",
-      default = Label("//src/tools/deploy_info"),
-      executable = True,
+        allow_single_file = True,
+        cfg = "exec",
+        default = Label("//src/tools/deploy_info"),
+        executable = True,
     ),
     translation_merger = attr.label(
         cfg = "exec",

--- a/toolchains/android/zipper.bzl
+++ b/toolchains/android/zipper.bzl
@@ -1,0 +1,151 @@
+"""Hermetic zip helpers backed by @bazel_tools//third_party/ijar:zipper."""
+
+HERMETIC_ZIPPER = Label("@bazel_tools//third_party/ijar:zipper")
+
+def _zipper_tool(ctx, attr_name = "_hermetic_zipper"):
+    return getattr(ctx.attr, attr_name)[DefaultInfo].files_to_run
+
+def _zipper_files_to_run(zipper):
+    """Return a FilesToRunProvider from a target label or provider."""
+    if hasattr(zipper, "executable"):
+        return zipper
+    return zipper[DefaultInfo].files_to_run
+
+def _zipper_paths(zipper):
+    """Return wrapper executable path and runfiles-resident binary path."""
+    executable = _zipper_files_to_run(zipper).executable
+    wrapper = executable.path
+    runfiles = wrapper + ".runfiles/bazel_tools/third_party/ijar/" + executable.basename
+    return wrapper, runfiles
+
+def zipper_sandbox_path(zipper):
+    """Return the wrapper executable path for a target or FilesToRunProvider."""
+    return _zipper_paths(zipper)[0]
+
+def zipper_resolve_bash(zipper, var_name = "zipper"):
+    """Return bash that sets ``var_name`` to a sandbox-usable ijar:zipper path."""
+    wrapper, runfiles = _zipper_paths(zipper)
+    return (
+        var_name + '="' + wrapper + '"\n' +
+        'if [[ ! -x "${' + var_name + '}" && -x "' + runfiles + '" ]]; then\n' +
+        '  ' + var_name + '="' + runfiles + '"\n' +
+        'fi\n' +
+        'if [[ "${' + var_name + '}" != /* && ! "${' + var_name + '}" =~ ^[A-Za-z]: ]]; then\n' +
+        '  ' + var_name + '="${PWD}/${' + var_name + '}"\n' +
+        'fi\n'
+    )
+
+def zipper_extract(
+        ctx,
+        *,
+        archive,
+        output_dir,
+        entries = None,
+        mnemonic = "ZipperExtract",
+        attr_name = "_hermetic_zipper"):
+    """Extract ``archive`` into ``output_dir`` using ijar:zipper."""
+    zipper_target = getattr(ctx.attr, attr_name)
+    entry_args = " ".join(['"{}"'.format(e) for e in entries]) if entries else ""
+    ctx.actions.run_shell(
+        tools = [zipper_target[DefaultInfo].files_to_run],
+        inputs = [archive],
+        outputs = [output_dir],
+        mnemonic = mnemonic,
+        command = """
+set -euo pipefail
+{resolve}
+archive="{archive}"
+outdir="{outdir}"
+[[ "${{archive}}" != /* && ! "${{archive}}" =~ ^[A-Za-z]: ]] && archive="${{PWD}}/${{archive}}"
+[[ "${{outdir}}" != /* && ! "${{outdir}}" =~ ^[A-Za-z]: ]] && outdir="${{PWD}}/${{outdir}}"
+mkdir -p "${{outdir}}"
+( cd "${{outdir}}" && "${{zipper}}" x "${{archive}}" {entries} )
+""".format(
+            resolve = zipper_resolve_bash(zipper_target),
+            archive = archive.path,
+            outdir = output_dir.path,
+            entries = entry_args,
+        ),
+        toolchain = None,
+    )
+
+def zipper_create(ctx, *, output, members, mnemonic = "ZipperCreate"):
+    """Create ``output`` from ``members`` as (archive_path, file) pairs.
+
+    Args:
+      ctx: The rule context.
+      output: Output archive file.
+      members: List of (archive_path, input_file) pairs.
+      mnemonic: Action mnemonic.
+    """
+    args = ["c", output.path]
+    for archive_path, input_file in members:
+        args.append("{}={}".format(archive_path, input_file.path))
+
+    ctx.actions.run(
+        executable = _zipper_tool(ctx),
+        arguments = args,
+        inputs = [member[1] for member in members],
+        outputs = [output],
+        mnemonic = mnemonic,
+        toolchain = None,
+    )
+
+def run_filter_zip_include(ctx, input_zip, output_zip, filters, zipper_target):
+    """Copy ``input_zip`` entries matching ``filters`` globs into ``output_zip``."""
+    filter_patterns = " ".join(['"{}"'.format(pattern) for pattern in filters])
+    ctx.actions.run_shell(
+        tools = [zipper_target[DefaultInfo].files_to_run],
+        inputs = [input_zip],
+        outputs = [output_zip],
+        mnemonic = "FilterZipInclude",
+        progress_message = "Filtering %s" % input_zip.short_path,
+        command = """
+set -euo pipefail
+{resolve}
+input="{input}"
+output="{output}"
+[[ "${{input}}" != /* && ! "${{input}}" =~ ^[A-Za-z]: ]] && input="${{PWD}}/${{input}}"
+[[ "${{output}}" != /* && ! "${{output}}" =~ ^[A-Za-z]: ]] && output="${{PWD}}/${{output}}"
+filters=({filters})
+staging=$(mktemp -d)
+trap 'rm -rf "${{staging}}"' EXIT
+( cd "${{staging}}" && "${{zipper}}" x "${{input}}" )
+args=()
+while IFS= read -r entry; do
+  [[ -z "${{entry}}" ]] && continue
+  include=0
+  if ((${{#filters[@]}} == 0)); then
+    include=1
+  else
+    for pattern in "${{filters[@]}}"; do
+      if [[ "${{entry}}" == ${{pattern}} ]]; then
+        include=1
+        break
+      fi
+    done
+  fi
+  if [[ "${{include}}" -eq 1 ]]; then
+    args+=("${{entry}}=${{staging}}/${{entry}}")
+  fi
+done < <("${{zipper}}" v "${{input}}" | awk '$1 == "f" {{print $3}}')
+if ((${{#args[@]}} == 0)); then
+  empty=$(mktemp)
+  : >"${{empty}}"
+  "${{zipper}}" c "${{output}}" "empty=${{empty}}"
+else
+  "${{zipper}}" c "${{output}}" "${{args[@]}}"
+fi
+""".format(
+            resolve = zipper_resolve_bash(zipper_target),
+            input = input_zip.path,
+            output = output_zip.path,
+            filters = filter_patterns,
+        ),
+    )
+
+def hermetic_zipper_attr():
+    return attr.label(
+        cfg = "exec",
+        default = HERMETIC_ZIPPER,
+    )

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -3,6 +3,7 @@ load("@rules_python//python:defs.bzl", "py_binary", "py_library", "py_test")
 load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 load("//rules:min_sdk_version.bzl", "min_sdk_version")
 load(":defs.bzl", "android_jar", "run_ijar", "run_singlejar")
+load(":desugar.bzl", "desugar_globals_jar", "extract_desugar_config_json")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -86,27 +87,17 @@ alias(
     visibility = ["//visibility:public"],
 )
 
-genrule(
+extract_desugar_config_json(
     name = "full_desugar_jdk_libs_config_json",
-    srcs = [
-        "@rules_android_maven//:com_android_tools_desugar_jdk_libs_configuration_nio",
-    ],
-    outs = ["full_desugar_jdk_libs_config.json"],
-    cmd = "unzip -q -c " +
-          "$(location @rules_android_maven//:com_android_tools_desugar_jdk_libs_configuration_nio) " +
-          "META-INF/desugar/d8/desugar.json > $@",
+    jar = "@rules_android_maven//:com_android_tools_desugar_jdk_libs_configuration_nio",
+    out = "full_desugar_jdk_libs_config.json",
     visibility = ["//visibility:public"],
 )
 
-genrule(
+extract_desugar_config_json(
     name = "minimal_desugar_jdk_libs_config_json",
-    srcs = [
-        "@rules_android_maven//:com_android_tools_desugar_jdk_libs_configuration_minimal",
-    ],
-    outs = ["minimal_desugar_jdk_libs_config.json"],
-    cmd = "unzip -q -c " +
-          "$(location @rules_android_maven//:com_android_tools_desugar_jdk_libs_configuration_minimal) " +
-          "META-INF/desugar/d8/desugar.json > $@",
+    jar = "@rules_android_maven//:com_android_tools_desugar_jdk_libs_configuration_minimal",
+    out = "minimal_desugar_jdk_libs_config.json",
 )
 
 genrule(
@@ -650,22 +641,9 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
-genrule(
+desugar_globals_jar(
     name = "desugar_globals_jar",
-    srcs = [":desugar_globals_classes.zip"],
-    outs = ["desugar_globals.jar"],
-    cmd = """
-    tmp=$$(mktemp -d)
-    unzip $(location :desugar_globals_classes.zip) -d $${tmp}
-    rm $${tmp}/kind
-    rm $${tmp}/compilerinfo
-    mv $${tmp}/com/android/tools/r8/RecordTag.global $${tmp}/com/android/tools/r8/RecordTag.class
-    mv $${tmp}/com/android/tools/r8/DesugarMethodHandlesLookup.global $${tmp}/com/android/tools/r8/DesugarMethodHandlesLookup.class
-    mv $${tmp}/com/android/tools/r8/DesugarVarHandle.global $${tmp}/com/android/tools/r8/DesugarVarHandle.class
-    mv $${tmp}'/com/android/tools/r8/DesugarVarHandle$$$$ExternalSyntheticBackportWithForwarding0.global' $${tmp}'/com/android/tools/r8/DesugarVarHandle$$$$ExternalSyntheticBackportWithForwarding0.class'
-    out=$$(pwd)/$(@)
-    cd $${tmp}
-    zip -r $${out} .
-""",
+    classes = ":desugar_globals_classes.zip",
+    out = "desugar_globals.jar",
     visibility = ["//visibility:public"],
 )

--- a/tools/android/build_java8_legacy_dex.sh
+++ b/tools/android/build_java8_legacy_dex.sh
@@ -91,8 +91,13 @@ if [[ -n "${binary_jar}" ]]; then
 
   if [[ ! -s "${rules}" ]]; then
     # No keep rules, meaning nothing to keep, so emit an empty zip
-    "$(rlocation rules_android/tools/android/zip)" -jt -X "${dest}" "${rules}"
-    "$(rlocation rules_android/tools/android/zip)" -jt -X -d "${dest}" "${rules}"
+    zipper="$(rlocation rules_android/tools/android/zip)"
+    if [[ ! -x "${zipper}" && -x "${zipper}.runfiles/bazel_tools/third_party/ijar/zipper" ]]; then
+      zipper="${zipper}.runfiles/bazel_tools/third_party/ijar/zipper"
+    fi
+    [[ "${zipper}" != /* ]] && zipper="${PWD}/${zipper}"
+    : > "${tmpdir}/empty"
+    "${zipper}" c "${dest}" "empty=${tmpdir}/empty"
     if [[ -n "${map}" ]]; then
       echo '# No desugared library mapping' > "${map}"
     fi

--- a/tools/android/desugar.bzl
+++ b/tools/android/desugar.bzl
@@ -1,0 +1,92 @@
+"""Starlark replacements for desugar genrules that previously called host zip/unzip."""
+
+load("//toolchains/android:zipper.bzl", "hermetic_zipper_attr", "zipper_extract", "zipper_resolve_bash")
+
+def _extract_desugar_config_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.out)
+    extracted = ctx.actions.declare_directory(ctx.label.name + "_extracted")
+    zipper_extract(
+        ctx,
+        archive = ctx.file.jar,
+        output_dir = extracted,
+        entries = ["META-INF/desugar/d8/desugar.json"],
+        mnemonic = "ExtractDesugarConfig",
+    )
+    ctx.actions.run_shell(
+        inputs = [extracted],
+        outputs = [out],
+        command = "cp '{src}/META-INF/desugar/d8/desugar.json' '{out}'".format(
+            src = extracted.path,
+            out = out.path,
+        ),
+        mnemonic = "WriteDesugarConfigJson",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+extract_desugar_config_json = rule(
+    implementation = _extract_desugar_config_impl,
+    attrs = {
+        "jar": attr.label(mandatory = True, allow_single_file = True),
+        "out": attr.string(mandatory = True),
+        "_hermetic_zipper": hermetic_zipper_attr(),
+    },
+)
+
+def _desugar_globals_jar_impl(ctx):
+    out = ctx.actions.declare_file(ctx.attr.out)
+    extracted = ctx.actions.declare_directory(ctx.label.name + "_extracted")
+    zipper_extract(
+        ctx,
+        archive = ctx.file.classes,
+        output_dir = extracted,
+        mnemonic = "ExtractDesugarGlobals",
+    )
+    resolve = zipper_resolve_bash(ctx.attr._hermetic_zipper)
+    ctx.actions.run_shell(
+        inputs = [extracted],
+        outputs = [out],
+        tools = [ctx.attr._hermetic_zipper[DefaultInfo].files_to_run],
+        command = (
+            resolve +
+            """
+set -euo pipefail
+src="{src}"
+out="{out}"
+[[ "${{src}}" != /* && ! "${{src}}" =~ ^[A-Za-z]: ]] && src="${{PWD}}/${{src}}"
+[[ "${{out}}" != /* && ! "${{out}}" =~ ^[A-Za-z]: ]] && out="${{PWD}}/${{out}}"
+work=$(mktemp -d)
+cp -R "${{src}}"/. "${{work}}"/
+cd "${{work}}"
+rm -f kind compilerinfo
+for f in $(find . -name '*.global'); do
+  mv "$f" "${{f%%.global}}.class"
+done
+args=()
+while IFS= read -r -d '' f; do
+  relpath=${{f#./}}
+  args+=("${{relpath}}=${{f}}")
+done < <(find . -type f -print0)
+if [ ${{#args[@]}} -eq 0 ]; then
+  empty=$(mktemp)
+  : >"${{empty}}"
+  "${{zipper}}" c "${{out}}" "empty=${{empty}}"
+else
+  "${{zipper}}" c "${{out}}" "${{args[@]}}"
+fi
+""".format(
+                src = extracted.path,
+                out = out.path,
+            )
+        ),
+        mnemonic = "RepackDesugarGlobalsJar",
+    )
+    return [DefaultInfo(files = depset([out]))]
+
+desugar_globals_jar = rule(
+    implementation = _desugar_globals_jar_impl,
+    attrs = {
+        "classes": attr.label(mandatory = True, allow_single_file = [".zip"]),
+        "out": attr.string(mandatory = True),
+        "_hermetic_zipper": hermetic_zipper_attr(),
+    },
+)

--- a/tools/jdk/create_system.sh
+++ b/tools/jdk/create_system.sh
@@ -59,7 +59,14 @@ DIR="$(mktemp -d)"
 
 mkdir -p "${DIR}/jmod" "${DIR}/classes"
 
-"${FLAGS_unzip}" -o -q -d "${DIR}/classes" "${FLAGS_input}"
+[[ "${FLAGS_unzip}" != /* && ! "${FLAGS_unzip}" =~ ^[A-Za-z]: ]] && FLAGS_unzip="${PWD}/${FLAGS_unzip}"
+runfiles="${FLAGS_unzip}.runfiles/bazel_tools/third_party/ijar/$(basename "${FLAGS_unzip}")"
+if [[ ! -x "${FLAGS_unzip}" && -x "${runfiles}" ]]; then
+  FLAGS_unzip="${runfiles}"
+fi
+[[ "${FLAGS_input}" != /* && ! "${FLAGS_input}" =~ ^[A-Za-z]: ]] && FLAGS_input="${PWD}/${FLAGS_input}"
+
+( cd "${DIR}/classes" && "${FLAGS_unzip}" x "${FLAGS_input}" )
 chmod -R a+rx "${DIR}/classes"
 
 rm -rf "${FLAGS_output}"

--- a/tools/jdk/system.bzl
+++ b/tools/jdk/system.bzl
@@ -16,6 +16,7 @@
 
 load("@rules_java//java:defs.bzl", "java_common")
 load("//rules:java.bzl", _java = "java")
+load("//toolchains/android:zipper.bzl", "zipper_sandbox_path")
 
 def _single_jar(ctx, inputs, output):
     _java.singlejar(
@@ -86,10 +87,11 @@ def _android_system(ctx):
 
     system = ctx.actions.declare_directory("%s_system" % ctx.label.name)
     java_runtime = ctx.attr._runtime[java_common.JavaRuntimeInfo]
+    unzip_target = ctx.attr._unzip
     args = ctx.actions.args()
     args.add("--input", core_jar)
     args.add("--output", system.path)
-    args.add("--unzip", ctx.executable._unzip)
+    args.add("--unzip", zipper_sandbox_path(unzip_target))
     args.add("--java_home", java_runtime.java_home)
     args.add("--module_info", module_info)
     ctx.actions.run(
@@ -100,7 +102,7 @@ def _android_system(ctx):
             ],
             transitive = [java_runtime.files],
         ),
-        tools = [ctx.executable._unzip],
+        tools = [unzip_target[DefaultInfo].files_to_run],
         outputs = [system],
         arguments = [args],
         executable = ctx.executable.create_system,
@@ -124,38 +126,6 @@ android_system = rule(
     implementation = _android_system,
     doc = "Creates a system directory for targeting the default android.jar.",
     attrs = {
-        "_java_toolchain": attr.label(
-            default = Label("//tools/jdk:current_java_toolchain"),
-        ),
-        "_unzip": attr.label(
-            executable = True,
-            cfg = "exec",
-            default = Label("//tools/android:unzip"),
-            allow_files = True,
-        ),
-        "_jar_to_module_info": attr.label(
-            executable = True,
-            cfg = "exec",
-            default = Label("//src/tools/jar_to_module_info"),
-            allow_files = True,
-        ),
-        "create_system": attr.label(
-            executable = True,
-            cfg = "exec",
-            default = Label("//tools/jdk:create_system"),
-            allow_files = True,
-        ),
-        "_split_core_jar": attr.label(
-            executable = True,
-            cfg = "exec",
-            default = Label("//src/tools/split_core_jar"),
-            allow_files = True,
-        ),
-        "_runtime": attr.label(
-            default = Label("//tools/jdk:current_java_runtime"),
-            cfg = "exec",
-            providers = [java_common.JavaRuntimeInfo],
-        ),
         "bootclasspath": attr.label_list(
             mandatory = True,
             allow_files = True,
@@ -164,11 +134,43 @@ android_system = rule(
             cfg = "target",
             allow_files = True,
         ),
+        "create_system": attr.label(
+            executable = True,
+            cfg = "exec",
+            default = Label("//tools/jdk:create_system"),
+            allow_files = True,
+        ),
         "exclusions": attr.string_list(),
         "overlay_jar": attr.label(
             cfg = "exec",
             allow_single_file = True,
             executable = False,
+        ),
+        "_jar_to_module_info": attr.label(
+            executable = True,
+            cfg = "exec",
+            default = Label("//src/tools/jar_to_module_info"),
+            allow_files = True,
+        ),
+        "_java_toolchain": attr.label(
+            default = Label("//tools/jdk:current_java_toolchain"),
+        ),
+        "_runtime": attr.label(
+            default = Label("//tools/jdk:current_java_runtime"),
+            cfg = "exec",
+            providers = [java_common.JavaRuntimeInfo],
+        ),
+        "_split_core_jar": attr.label(
+            executable = True,
+            cfg = "exec",
+            default = Label("//src/tools/split_core_jar"),
+            allow_files = True,
+        ),
+        "_unzip": attr.label(
+            executable = True,
+            cfg = "exec",
+            default = Label("//tools/android:unzip"),
+            allow_files = True,
         ),
         # TODO(b/281980093): No matching toolchains found for types //tools/jdk:runtime_toolchain_type.
         "_use_auto_exec_groups": attr.bool(default = False),


### PR DESCRIPTION
## Summary

- Point Android toolchain `:zip` / `:unzip` at `@bazel_tools//third_party/ijar:zipper` instead of host `zip`/`unzip` stubs
- Add shared Starlark helpers and replace desugar genrules with rules that call `zipper` via `ctx.actions.run`
- Update remaining shell call sites (`create_system`, databinding resource fix, `build_java8_legacy_dex`) to use zipper native x/v/c interface
- Use `ijar:zipper` for aapt2 proto extraction genrules (`Configuration.proto`, `Resources.proto`, `ResourcesInternal.proto`)

Remote executors with `--incompatible_strict_action_env` do not provide host `zip`/`unzip`, which breaks Android builds on RBE.

## Test plan

- [ ] Build Android targets that exercise desugar config extraction and `desugar_globals_jar`
- [ ] Build an `android_library` with databinding enabled
- [ ] Build `//src/tools/java/com/google/devtools/build/android/proto:Configuration_proto_file`