### PR TITLE
android_binary: Omit output_jar_creator to prevent MANIFEST.MF clash …

### DIFF
--- a/rules/android_binary/impl.bzl
+++ b/rules/android_binary/impl.bzl
@@ -952,7 +952,6 @@ def _process_apk_packaging(ctx, packaged_resources_ctx, native_libs_ctx, dex_ctx
             "experimental_android_compress_java_resources",
         ),
         nocompress_extensions = ctx.attr.nocompress_extensions,
-        output_jar_creator = "bazel",
         signing_keys = signing_keys,
         signing_lineage = ctx.file.debug_signing_lineage_file,
         signing_key_rotation_min_sdk = ctx.attr.key_rotation_min_sdk,


### PR DESCRIPTION
…in Android App Bundles

Passing output_jar_creator = "bazel" during base APK packaging causes SingleJar to write "Created-By: bazel" (44 bytes) into base/root/META-INF/MANIFEST.MF.

However, feature module packaging (_process_feature_module) invokes SingleJar without output_jar_creator, defaulting to "Created-By: singlejar" (48 bytes) for feature/root/META-INF/MANIFEST.MF.

When Bundletool validates duplicate entries across module ZIPs, this SHA-256 content mismatch triggers an InvalidBundleException: "Modules 'base' and 'feature1' contain entry 'root/META-INF/MANIFEST.MF' with different content."

Omitting output_jar_creator in android_binary allows SingleJar to use its default "singlejar" creator string for both base and feature modules, ensuring identical MANIFEST.MF contents and enabling successful bundle creation.

Change-Id: I99089f1ee441ba3d418d619dffcfe6a26a6a6964