### PR TITLE
Prevent DexFileSplitter from dropping colliding class names

### DIFF
--- a/src/tools/java/com/google/devtools/build/android/dexer/ZipEntryComparator.java
+++ b/src/tools/java/com/google/devtools/build/android/dexer/ZipEntryComparator.java
@@ -44,6 +44,9 @@ enum ZipEntryComparator implements Comparator<ZipEntry> {
   // Copied from com.android.dx.cf.direct.ClassPathOpener
   @VisibleForTesting
   static int compareClassNames(String a, String b) {
+    String originalA = a;
+    String originalB = b;
+
     // Ensure inner classes sort second
     a = a.replace('$', '0');
     b = b.replace('$', '0');
@@ -55,6 +58,13 @@ enum ZipEntryComparator implements Comparator<ZipEntry> {
     a = a.replace("package-info", "");
     b = b.replace("package-info", "");
 
-    return a.compareTo(b);
+    int normalizedResult = a.compareTo(b);
+    if (normalizedResult != 0) {
+      return normalizedResult;
+    }
+
+    // Normalization is lossy. Keep distinct raw names distinct when this comparator is used as a
+    // TreeMap key comparator, otherwise entries such as Foo$2$1$1 and Foo$2$101 collapse.
+    return originalA.compareTo(originalB);
   }
 }

--- a/src/tools/javatests/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
+++ b/src/tools/javatests/com/google/devtools/build/android/dexer/DexFileSplitterTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
 import java.util.zip.CRC32;
 import java.util.zip.ZipEntry;
@@ -121,6 +122,19 @@ public class DexFileSplitterTest {
 
     ImmutableSet<String> expectedFiles = dexEntries(simpleDexArchive);
     assertThat(dexEntries(outputArchives.get(0))).containsExactlyElementsIn(expectedFiles);
+  }
+
+  @Test
+  public void testClassNameComparatorPreservesNormalizationCollisions() {
+    TreeMap<String, Boolean> classNames =
+        new TreeMap<>(ZipEntryComparator::compareClassNames);
+
+    classNames.put("Foo$2$1$1.class.dex", true);
+    classNames.put("Foo$2$101.class.dex", true);
+
+    assertThat(classNames.keySet())
+        .containsExactly("Foo$2$1$1.class.dex", "Foo$2$101.class.dex")
+        .inOrder();
   }
 
   @Test


### PR DESCRIPTION
## Problem

`DexFileSplitter` stores input entries in a `TreeMap` using `ZipEntryComparator::compareClassNames`, then inserts them with `putIfAbsent`. The comparator replaces `$` with `0` before comparing names.

When generated nested class names include entries such as `Foo$2$1$1.class.dex` and `Foo$2$101.class.dex`, both normalize to the same value. The comparator therefore returns zero, the `TreeMap` treats the distinct classes as the same key, and `putIfAbsent` silently drops one. The resulting APK can fail at runtime with `NoClassDefFoundError` for the missing class.

## Change

Keep the existing dx-style normalized ordering. When two normalized names compare equal, fall back to comparing the original names so distinct entries remain distinct. No ordering changes for names whose normalized forms differ.

Add regression coverage that inserts the colliding names into the same `TreeMap` shape used by `DexFileSplitter` and verifies that both remain present.

## Testing

- Passed a self-contained `javac` regression check against the modified `ZipEntryComparator`.
- Added the collision case to `DexFileSplitterTest`.
- Attempted `bazel test //src/tools/javatests/com/google/devtools/build/android/dexer:AllTests --test_output=errors`; repository analysis could not complete locally because connections to `maven.google.com` timed out before compilation or test execution.