### PR TITLE
Follow-up implicit output test for #547

### DIFF
--- a/test/rules/android_binary/r8_integration/BUILD
+++ b/test/rules/android_binary/r8_integration/BUILD
@@ -6,7 +6,7 @@ load(
 )
 load("@rules_python//python:py_test.bzl", "py_test")
 load("@rules_shell//shell:sh_library.bzl", "sh_library")
-load(":test.bzl", "r8_neverlink_deps_test")
+load(":test.bzl", "r8_implicit_outputs_test", "r8_neverlink_deps_test")
 
 py_test(
     name = "r8_integration_test",
@@ -19,6 +19,11 @@ py_test(
         "//test/rules/android_binary/r8_integration/java/com/basicapp:basic_app_select_R8_generate_pg_map",
         "@androidsdk//:dexdump",
     ],
+)
+
+r8_implicit_outputs_test(
+    name = "r8_implicit_outputs_test",
+    target_under_test = "//test/rules/android_binary/r8_integration/java/com/neverlink:android_binary_with_neverlink_deps",
 )
 
 r8_neverlink_deps_test(

--- a/test/rules/android_binary/r8_integration/test.bzl
+++ b/test/rules/android_binary/r8_integration/test.bzl
@@ -55,3 +55,29 @@ def r8_neverlink_deps_test_impl(ctx):
 r8_neverlink_deps_test = analysistest.make(
     impl = r8_neverlink_deps_test_impl,
 )
+
+def r8_implicit_outputs_test_impl(ctx):
+    """Tests that R8 declares proguard_mappings_output_file as implicit_outputs.
+
+    Args:
+        ctx: The ctx.
+
+    Returns:
+        The providers.
+    """
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+
+    default_files = [f.basename for f in target[DefaultInfo].files.to_list()]
+    expected_map = target.label.name + "_proguard.map"
+    asserts.true(
+        env,
+        expected_map in default_files,
+        "Expected %s to be in default outputs %s" % (expected_map, default_files),
+    )
+
+    return analysistest.end(env)
+
+r8_implicit_outputs_test = analysistest.make(
+    impl = r8_implicit_outputs_test_impl,
+)


### PR DESCRIPTION
#547 modified the R8 rule's implicit outputs. This change adds an analysis test to verify that change.