### PR TITLE
Add java.lang.constant to the extra bootclasspath jar for ImportDepsChecker

### DIFF
--- a/test/rules/aar_import/AndroidManifest.xml
+++ b/test/rules/aar_import/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.sample">
+</manifest>

--- a/test/rules/aar_import/BUILD
+++ b/test/rules/aar_import/BUILD
@@ -1,0 +1,33 @@
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_java//java:java_library.bzl", "java_library")
+load("//rules:rules.bzl", "aar_import")
+
+java_library(
+    name = "sample_classes",
+    srcs = ["java/com/sample/Sample.java"],
+)
+
+genrule(
+    name = "gen_sample_aar",
+    srcs = [
+        "AndroidManifest.xml",
+        ":libsample_classes.jar",
+    ],
+    outs = ["sample.aar"],
+    cmd = "$(location @bazel_tools//tools/zip:zipper) c $@ " +
+          "AndroidManifest.xml=$(location AndroidManifest.xml) " +
+          "classes.jar=$(location :libsample_classes.jar)",
+    tools = ["@bazel_tools//tools/zip:zipper"],
+)
+
+aar_import(
+    name = "sample_aar",
+    aar = ":sample.aar",
+)
+
+# Checks that ImportDepsChecker validation passes for classes that use
+# lambdas or string concatenation.
+build_test(
+    name = "sample_aar_import_build_test",
+    targets = [":sample_aar"],
+)

--- a/test/rules/aar_import/java/com/sample/Sample.java
+++ b/test/rules/aar_import/java/com/sample/Sample.java
@@ -1,0 +1,9 @@
+package com.sample;
+
+/** Uses a lambda and string concatenation to reference java.lang.invoke. */
+public class Sample {
+
+  public static Runnable task(String name) {
+    return () -> System.out.println("task " + name);
+  }
+}

--- a/tools/android/BUILD
+++ b/tools/android/BUILD
@@ -389,6 +389,7 @@ run_singlejar(
     include_prefixes = [
         "java/lang/invoke/",
         "java/lang/annotation/",
+        "java/lang/constant/",
     ],
     visibility = ["//visibility:private"],
 )


### PR DESCRIPTION
Since JDK 12, java.lang.invoke.MethodHandle and MethodType implement java.lang.constant.Constable. With a JDK 17 toolchain, ImportDepsChecker reports "Missing java.lang.constant.Constable" for any aar_import whose classes use lambdas or string concatenation, because only java/lang/invoke and java/lang/annotation were extracted from the platform classpath.

Add an aar_import sample whose classes.jar uses a lambda and string concatenation, so the ImportDepsChecker validation covers this case:

  bazel test //test/rules/aar_import:sample_aar_import_build_test

Fixes https://github.com/bazelbuild/rules_android/issues/495
Fixes https://github.com/bazelbuild/rules_android/issues/451