### PR TITLE
Extract android_local_test coverage runtime processor

### DIFF
--- a/rules/android_local_test/impl.bzl
+++ b/rules/android_local_test/impl.bzl
@@ -13,6 +13,10 @@
 # limitations under the License.
 """Bazel rule for Android local test."""
 
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@rules_java//java/common:java_common.bzl", "java_common")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("@rules_java//java/common:java_plugin_info.bzl", "JavaPluginInfo")
 load("//providers:providers.bzl", "AndroidFilteredJdepsInfo")
 load("//rules:add_constraints.bzl", "add_constraints")
 load("//rules:attrs.bzl", "attrs")
@@ -39,10 +43,6 @@ load(
     "utils",
 )
 load("//rules:visibility.bzl", "PROJECT_VISIBILITY")
-load("@rules_java//java/common:java_common.bzl", "java_common")
-load("@rules_java//java/common:java_info.bzl", "JavaInfo")
-load("@rules_java//java/common:java_plugin_info.bzl", "JavaPluginInfo")
-load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 visibility(PROJECT_VISIBILITY)
 
@@ -134,13 +134,18 @@ def _process_resources(ctx, java_package, manifest_ctx, **_unused_sub_ctxs):
         value = resources_ctx,
     )
 
-def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
-    deps = (
-        ctx.attr._implicit_classpath +
-        ctx.attr.deps +
-        [get_android_toolchain(ctx).testsupport]
-    )
+def _process_coverage(ctx, **_unused_sub_ctxs):
+    """Supplies coverage runtime configuration to the JVM and stub processors.
 
+    Replace CoverageProcessor to select a different coverage runtime. Return
+    coverage_ctx with deps (Java targets), java_start_class, coverage_start_class
+    (the JaCoCo delegate main class, or None), and additional_jvm_flags. Agent
+    jars and configuration files can be supplied via ProviderInfo.runfiles.
+
+    This configures execution only; compilation processors remain responsible
+    for selecting bytecode instrumentation.
+    """
+    deps = []
     target_runner_class = ctx.attr.main_class
 
     if ctx.configuration.coverage_enabled:
@@ -150,6 +155,24 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
     else:
         java_start_class = target_runner_class
         coverage_start_class = None
+
+    return ProviderInfo(
+        name = "coverage_ctx",
+        value = struct(
+            deps = deps,
+            java_start_class = java_start_class,
+            coverage_start_class = coverage_start_class,
+            additional_jvm_flags = [],
+        ),
+    )
+
+def _process_jvm(ctx, resources_ctx, coverage_ctx, **_unused_sub_ctxs):
+    deps = (
+        ctx.attr._implicit_classpath +
+        ctx.attr.deps +
+        [get_android_toolchain(ctx).testsupport] +
+        coverage_ctx.deps
+    )
 
     java_info = java.compile_android(
         ctx,
@@ -194,10 +217,10 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
             java_info = java_info,
             providers = providers,
             deps = deps,
-            java_start_class = java_start_class,
-            coverage_start_class = coverage_start_class,
+            java_start_class = coverage_ctx.java_start_class,
+            coverage_start_class = coverage_ctx.coverage_start_class,
             android_properties_file = ctx.file.robolectric_properties_file.short_path,
-            additional_jvm_flags = [],
+            additional_jvm_flags = coverage_ctx.additional_jvm_flags,
         ),
         runfiles = ctx.runfiles(files = runfiles),
     )
@@ -332,6 +355,7 @@ PROCESSORS = dict(
     ValidationsProcessor = _validations_processor,
     ManifestProcessor = _process_manifest,
     ResourceProcessor = _process_resources,
+    CoverageProcessor = _process_coverage,
     JvmProcessor = _process_jvm,
     ProtoProcessor = _process_proto,
     DeployJarProcessor = _process_deploy_jar,

--- a/test/rules/android_local_test/BUILD
+++ b/test/rules/android_local_test/BUILD
@@ -1,5 +1,6 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//rules:rules.bzl", "android_local_test")
+load(":coverage_test.bzl", "coverage_test_suite")
 load(":java_launcher_integration_test.bzl", "android_local_test_launcher_integration_test_suite")
 load(":java_launcher_test.bzl", "android_local_test_launcher_test_suite")
 
@@ -20,10 +21,15 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:private"],
     deps = [
+        "//rules:common_bzl",
         "//rules:visibility_bzl",
+        "//rules/android_local_test:bzl",
+        "@bazel_skylib//lib:unittest",
         "@rules_java//java/common",
     ],
 )
+
+coverage_test_suite(name = "coverage_tests")
 
 android_local_test(
     name = "sample_test_default_launcher",

--- a/test/rules/android_local_test/coverage_test.bzl
+++ b/test/rules/android_local_test/coverage_test.bzl
@@ -1,0 +1,126 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Analysis tests and a make_rule prototype for custom coverage runtimes."""
+
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@rules_java//java/common:java_info.bzl", "JavaInfo")
+load("//rules:java.bzl", "java")
+load("//rules:processing_pipeline.bzl", "ProviderInfo", "processing_pipeline")
+load("//rules/android_local_test:attrs.bzl", "ATTRS")
+load("//rules/android_local_test:impl.bzl", "JACOCOCO_CLASS", "PROCESSORS", "finalize")
+load("//rules/android_local_test:rule.bzl", "make_rule")
+
+def _custom_coverage(ctx, **sub_ctxs):
+    if not ctx.configuration.coverage_enabled:
+        return PROCESSORS["CoverageProcessor"](ctx, **sub_ctxs)
+
+    # Analysis-only stand-ins: a real integration obtains the agent from its
+    # toolchain and writes the coverage tool's configuration here.
+    agent = ctx.actions.declare_file(ctx.label.name + "_agent.jar")
+    args = ctx.actions.declare_file(ctx.label.name + "_agent.args")
+    ctx.actions.write(agent, "")
+    ctx.actions.write(args, "")
+    return ProviderInfo(
+        name = "coverage_ctx",
+        value = struct(
+            deps = [],
+            java_start_class = ctx.attr.main_class,
+            coverage_start_class = None,
+            additional_jvm_flags = ["-javaagent:%s=file:%s" % (agent.short_path, args.short_path)],
+        ),
+        runfiles = ctx.runfiles(files = [agent, args]),
+    )
+
+_CUSTOM_PIPELINE = processing_pipeline.make_processing_pipeline(
+    processors = processing_pipeline.replace(PROCESSORS, CoverageProcessor = _custom_coverage),
+    finalize = finalize,
+)
+
+def _custom_impl(ctx):
+    java_package = java.resolve_package_from_label(ctx.label, ctx.attr.custom_package)
+    return processing_pipeline.run(ctx, java_package, _CUSTOM_PIPELINE)
+
+_TEST_ATTRS = dict(ATTRS, main_class = attr.string(default = "example.CustomRunner"))
+_custom_android_local_test = make_rule(attrs = _TEST_ATTRS, implementation = _custom_impl)
+_default_android_local_test = make_rule(attrs = _TEST_ATTRS)
+
+def _coverage_test_impl(ctx):
+    env = analysistest.begin(ctx)
+    target = analysistest.target_under_test(env)
+    executable = target[DefaultInfo].files_to_run.executable
+    actions = [a for a in analysistest.target_actions(env) if executable in a.outputs.to_list()]
+    asserts.equals(env, 1, len(actions))
+    subs = actions[0].substitutions
+    jacoco = ctx.attr.mode == "jacoco"
+    agent = ctx.attr.mode == "agent"
+
+    asserts.equals(env, JACOCOCO_CLASS if jacoco else "example.CustomRunner", subs["%java_start_class%"])
+    asserts.equals(env, jacoco, bool(subs["%set_jacoco_metadata%"]))
+    asserts.equals(env, "export JACOCO_MAIN_CLASS=example.CustomRunner" if jacoco else "", subs["%set_jacoco_main_class%"])
+    asserts.equals(env, jacoco, bool(subs["%set_jacoco_java_runfiles_root%"]))
+    asserts.equals(env, agent, "-javaagent:" in subs["%jvm_flags%"])
+    asserts.true(env, "-Dbazel.test_suite=example.ExampleTest" in subs["%jvm_flags%"])
+    asserts.true(env, "-Drobolectric.offline=true" in subs["%jvm_flags%"])
+    asserts.true(env, "-Duser.flag=retained" in subs["%jvm_flags%"])
+
+    runtime_jars = target[JavaInfo].transitive_runtime_jars.to_list()
+    asserts.equals(env, jacoco, any(["jacoco" in f.basename.lower() for f in runtime_jars]))
+    runfiles = target[DefaultInfo].default_runfiles.files.to_list()
+    agent_files = [f for f in runfiles if f.basename.endswith(("_agent.jar", "_agent.args"))]
+    asserts.equals(env, 2 if agent else 0, len(agent_files))
+    for f in agent_files:
+        asserts.true(env, f.short_path in subs["%jvm_flags%"])
+    asserts.true(env, any([f.basename == target.label.name + "_deploy.jar" for f in runfiles]))
+    if jacoco:
+        asserts.true(env, target.label.name + "_deploy.jar" in subs["%set_jacoco_metadata%"])
+    return analysistest.end(env)
+
+_coverage_test = analysistest.make(
+    _coverage_test_impl,
+    config_settings = {"//command_line_option:collect_code_coverage": True},
+    attrs = {"mode": attr.string()},
+)
+_no_coverage_test = analysistest.make(
+    _coverage_test_impl,
+    config_settings = {"//command_line_option:collect_code_coverage": False},
+    attrs = {"mode": attr.string(default = "off")},
+)
+
+def coverage_test_suite(name):
+    """Checks default JaCoCo, custom agent, and coverage-disabled launchers.
+
+    Args:
+      name: Name of the test suite.
+    """
+    tests = []
+    for variant, test_rule in [("default", _default_android_local_test), ("custom", _custom_android_local_test)]:
+        subject = name + "_" + variant + "_subject"
+        test_rule(
+            name = subject,
+            custom_package = "example",
+            test_class = "example.ExampleTest",
+            jvm_flags = ["-Duser.flag=retained"],
+            tags = ["manual"],
+        )
+        _coverage_test(
+            name = name + "_" + variant,
+            target_under_test = ":" + subject,
+            mode = "jacoco" if variant == "default" else "agent",
+        )
+        _no_coverage_test(
+            name = name + "_" + variant + "_off",
+            target_under_test = ":" + subject,
+        )
+        tests.extend([":" + name + "_" + variant, ":" + name + "_" + variant + "_off"])
+    native.test_suite(name = name, tests = tests)


### PR DESCRIPTION
Custom android_local_test implementations currently mix coverage runtime selection with JVM compilation. Extract that selection into a replaceable `CoverageProcessor`, so custom rules can supply runner dependencies, entry classes, JVM flags, and agent runfiles while reusing the existing JVM and stub processors. Default JaCoCo behavior and the existing `jvm_ctx` fields are preserved.

Add four analysis tests for default JaCoCo and a custom agent, with coverage enabled and disabled. Register them in the Android local-test BUILD file.

Validation:
- All four tests in `//test/rules/android_local_test:coverage_tests` pass.
- `//test/rules/android_local_test:bzl` builds; Buildifier formatting/lint and `git diff --check` pass.
- The existing default-launcher test has a JDK runfile-path mismatch that also reproduces on unmodified upstream.

This configures the coverage runtime only; compiler instrumentation and coverage report generation remain separate. The custom-agent tests inspect analysis outputs rather than running a coverage engine.

Related: https://github.com/bazel-contrib/rules_kotlin/pull/1729
